### PR TITLE
avoid percent calculation with crazy outliars

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -38,7 +38,7 @@ if (config.amplitude && config.amplitude.key) {
 
 let dataWarehouse;
 
-const { firehose: { meetingStatsStream, pcStatsStream, region: firehoseAwsRegion }} = config;
+const { firehose: { meetingStatsStream, pcStatsStream, region: firehoseAwsRegion } } = config;
 
 if (meetingStatsStream && pcStatsStream && firehoseAwsRegion) {
 

--- a/src/features/quality-stats/StatsAggregator.js
+++ b/src/features/quality-stats/StatsAggregator.js
@@ -38,10 +38,20 @@ class StatsAggregator {
             }
         });
 
-        const sentPacketsLostPct = (totalPacketsSent
-            && percentOf(totalSentPacketsLost, totalPacketsSent)) || 0;
-        const receivedPacketsLostPct = (totalPacketsReceived
-            && percentOf(totalReceivedPacketsLost, totalPacketsReceived)) || 0;
+        let sentPacketsLostPct = 0;
+
+        if (totalPacketsSent
+            && totalSentPacketsLost > 0
+            && totalSentPacketsLost < totalPacketsSent) {
+            sentPacketsLostPct = percentOf(totalSentPacketsLost, totalPacketsSent) || 0;
+        }
+        let receivedPacketsLostPct = 0;
+
+        if (totalPacketsReceived
+            && totalReceivedPacketsLost > 0
+            && totalReceivedPacketsLost < totalPacketsReceived) {
+            receivedPacketsLostPct = percentOf(totalReceivedPacketsLost, totalPacketsReceived) || 0;
+        }
 
         return {
             totalSentPacketsLost,


### PR DESCRIPTION
So we get packetLoss below 0 and higher than the sent/received packets. This PR doesn't attempt to calculate the packet loss percentage in these cases.