### PR TITLE
Add packet loss variant and tracks

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -9,6 +9,7 @@ firehose:
     region: RTCSTATS_FIREHOSE_AWS_REGION
     meetingStatsStream: RTCSTATS_FIREHOSE_MEETING_STREAM
     pcStatsStream: RTCSTATS_FIREHOSE_PC_STREAM
+    trackStatsStream: RTCSTATS_FIREHOSE_TRACKS_STREAM
 
 s3:
     region: RTCSTATS_S3_AWS_REGION

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -32,6 +32,7 @@ firehose:
     region:
     meetingStatsStream:
     pcStatsStream:
+    trackStatsStream:
 
 gcp:
     bucket:

--- a/src/app.js
+++ b/src/app.js
@@ -38,9 +38,9 @@ if (config.amplitude && config.amplitude.key) {
 
 let dataWarehouse;
 
-const { firehose: { meetingStatsStream, pcStatsStream, region: firehoseAwsRegion } } = config;
+const { firehose: { meetingStatsStream, pcStatsStream, trackStatsStream, region: firehoseAwsRegion } } = config;
 
-if (meetingStatsStream && pcStatsStream && firehoseAwsRegion) {
+if (meetingStatsStream && pcStatsStream && trackStatsStream && firehoseAwsRegion) {
 
     const appEnv = config.server?.appEnvironment;
 

--- a/src/test/jest/results/chrome96-standard-stats-p2p-add-transceiver-result.json
+++ b/src/test/jest/results/chrome96-standard-stats-p2p-add-transceiver-result.json
@@ -54,6 +54,40 @@
             "totalPacketsReceived": 4008,
             "receivedPacketsLostPct": 0
           },
+          "tracks": {
+            "receiverTracks": {
+              "30949311": {
+                "mediaType": "audio",
+                "packets": 977,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "3482054886": {
+                "mediaType": "video",
+                "packets": 3031,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              }
+            },
+            "senderTracks": {
+              "3500323962": {
+                "mediaType": "video",
+                "packets": 2970,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "3752551346": {
+                "mediaType": "audio",
+                "packets": 977,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              }
+            }
+          },
           "transportAggregates": {
             "meanRtt": 0
           }
@@ -69,6 +103,54 @@
             "totalReceivedPacketsLost": 0,
             "totalPacketsReceived": 51,
             "receivedPacketsLostPct": 0
+          },
+          "tracks": {
+            "receiverTracks": {
+              "1838074254": {
+                "mediaType": "audio",
+                "packets": 0,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "1993617966": {
+                "mediaType": "video",
+                "packets": 33,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "2040317954": {
+                "mediaType": "video",
+                "packets": 0,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "2936577150": {
+                "mediaType": "audio",
+                "packets": 18,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              }
+            },
+            "senderTracks": {
+              "1478613941": {
+                "mediaType": "video",
+                "packets": 65,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "8040383": {
+                "mediaType": "audio",
+                "packets": 18,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              }
+            }
           },
           "transportAggregates": {
             "meanRtt": 40.33

--- a/src/test/jest/results/firefox-standard-stats-sfu-result.json
+++ b/src/test/jest/results/firefox-standard-stats-sfu-result.json
@@ -54,6 +54,96 @@
             "totalReceivedPacketsLost": 8,
             "totalSentPacketsLost": 0
           },
+          "tracks": {
+            "receiverTracks": {
+              "1291750480": {
+                "mediaType": "audio",
+                "packets": 6778,
+                "packetsLost": 3,
+                "packetsLostPct": 0.04,
+                "packetsLostVariance": 0.0399305555555556
+              },
+              "1426121629": {
+                "mediaType": "audio",
+                "packets": 7683,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "1449778799": {
+                "mediaType": "audio",
+                "packets": 6065,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "2047229442": {
+                "mediaType": "video",
+                "packets": 7177,
+                "packetsLost": 1,
+                "packetsLostPct": 0.01,
+                "packetsLostVariance": 0.014921946740128528
+              },
+              "2403718901": {
+                "mediaType": "video",
+                "packets": 8352,
+                "packetsLost": 2,
+                "packetsLostPct": 0.02,
+                "packetsLostVariance": 0.027006172839506123
+              },
+              "271883463": {
+                "mediaType": "video",
+                "packets": 4580,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "4051566705": {
+                "mediaType": "audio",
+                "packets": 7770,
+                "packetsLost": 1,
+                "packetsLostPct": 0.01,
+                "packetsLostVariance": 0.012818350480688152
+              },
+              "876450406": {
+                "mediaType": "audio",
+                "packets": 3229,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "891790093": {
+                "mediaType": "video",
+                "packets": 8408,
+                "packetsLost": 1,
+                "packetsLostPct": 0.01,
+                "packetsLostVariance": 0.012818350480688152
+              },
+              "972539169": {
+                "mediaType": "video",
+                "packets": 2417,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              }
+            },
+            "senderTracks": {
+              "1426121629": {
+                "mediaType": "audio",
+                "packets": 0,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "271883463": {
+                "mediaType": "video",
+                "packets": 0,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              }
+            }
+          },
           "transportAggregates": {
             "meanRtt": 0.05
           }

--- a/src/test/jest/results/firefox97-standard-stats-sfu-result.json
+++ b/src/test/jest/results/firefox97-standard-stats-sfu-result.json
@@ -54,6 +54,68 @@
             "totalPacketsReceived": 4294935897,
             "receivedPacketsLostPct": 0
           },
+          "tracks": {
+            "receiverTracks": {
+              "2555995057": {
+                "mediaType": "audio",
+                "packets": 3366,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "275935317": {
+                "mediaType": "video",
+                "packets": 4294906587,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "3145113315": {
+                "mediaType": "video",
+                "packets": 11779,
+                "packetsLost": 28,
+                "packetsLostPct": 0.24,
+                "packetsLostVariance": 8.888888888888891
+              },
+              "420677523": {
+                "mediaType": "video",
+                "packets": 12076,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "676202912": {
+                "mediaType": "video",
+                "packets": 2089,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              }
+            },
+            "senderTracks": {
+              "275935317": {
+                "mediaType": "video",
+                "packets": 0,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "420677523": {
+                "mediaType": "video",
+                "packets": 0,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "676202912": {
+                "mediaType": "video",
+                "packets": 0,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              }
+            }
+          },
           "transportAggregates": {
             "meanRtt": 0.04
           }

--- a/src/test/jest/results/google-standard-stats-p2p-result.json
+++ b/src/test/jest/results/google-standard-stats-p2p-result.json
@@ -54,6 +54,40 @@
             "totalReceivedPacketsLost": 0,
             "totalSentPacketsLost": 0
           },
+          "tracks": {
+            "receiverTracks": {
+              "250981789": {
+                "mediaType": "audio",
+                "packets": 2645,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "2864088180": {
+                "mediaType": "video",
+                "packets": 9585,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              }
+            },
+            "senderTracks": {
+              "2364213263": {
+                "mediaType": "audio",
+                "packets": 2642,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "9891702": {
+                "mediaType": "video",
+                "packets": 8421,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              }
+            }
+          },
           "transportAggregates": {
             "meanRtt": 0
           }
@@ -69,6 +103,96 @@
             "totalPacketsSent": 6317,
             "totalReceivedPacketsLost": 36,
             "totalSentPacketsLost": 11
+          },
+          "tracks": {
+            "receiverTracks": {
+              "1030784244": {
+                "mediaType": "video",
+                "packets": 738,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "1052990334": {
+                "mediaType": "video",
+                "packets": 1031,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "1527498116": {
+                "mediaType": "video",
+                "packets": 334,
+                "packetsLost": 36,
+                "packetsLostPct": 10.78,
+                "packetsLostVariance": 25.401599999999995
+              },
+              "1661050740": {
+                "mediaType": "audio",
+                "packets": 354,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "1845975655": {
+                "mediaType": "video",
+                "packets": 39,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "2566963332": {
+                "mediaType": "audio",
+                "packets": 82,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "3489317734": {
+                "mediaType": "audio",
+                "packets": 1163,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "757648711": {
+                "mediaType": "audio",
+                "packets": 1267,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              }
+            },
+            "senderTracks": {
+              "1191903134": {
+                "mediaType": "video",
+                "packets": 163,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "1409401962": {
+                "mediaType": "video",
+                "packets": 2905,
+                "packetsLost": 7,
+                "packetsLostPct": 0.24,
+                "packetsLostVariance": 0.9603999999999988
+              },
+              "2545347749": {
+                "mediaType": "audio",
+                "packets": 2334,
+                "packetsLost": 2,
+                "packetsLostPct": 0.09,
+                "packetsLostVariance": 0.07839999999999991
+              },
+              "3077306155": {
+                "mediaType": "video",
+                "packets": 915,
+                "packetsLost": 2,
+                "packetsLostPct": 0.22,
+                "packetsLostVariance": 0.07839999999999991
+              }
+            }
           },
           "transportAggregates": {
             "meanRtt": 0.05

--- a/src/test/jest/results/google-standard-stats-sfu-result.json
+++ b/src/test/jest/results/google-standard-stats-sfu-result.json
@@ -54,6 +54,68 @@
             "totalReceivedPacketsLost": 9,
             "totalSentPacketsLost": 0
           },
+          "tracks": {
+            "receiverTracks": {
+              "1030784244": {
+                "mediaType": "video",
+                "packets": 4473,
+                "packetsLost": 2,
+                "packetsLostPct": 0.04,
+                "packetsLostVariance": 0.12109375
+              },
+              "1661050740": {
+                "mediaType": "audio",
+                "packets": 3253,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "1845975655": {
+                "mediaType": "video",
+                "packets": 4385,
+                "packetsLost": 5,
+                "packetsLostPct": 0.11,
+                "packetsLostVariance": 0.1943359375
+              },
+              "3489317734": {
+                "mediaType": "audio",
+                "packets": 3252,
+                "packetsLost": 2,
+                "packetsLostPct": 0.06,
+                "packetsLostVariance": 0.12109375
+              },
+              "428706097": {
+                "mediaType": "video",
+                "packets": 1898,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "757648711": {
+                "mediaType": "audio",
+                "packets": 2234,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              }
+            },
+            "senderTracks": {
+              "1950053863": {
+                "mediaType": "video",
+                "packets": 2026,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "3525379525": {
+                "mediaType": "audio",
+                "packets": 3254,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              }
+            }
+          },
           "transportAggregates": {
             "meanRtt": 0.05
           }

--- a/src/test/jest/results/safari-standard-stats-result.json
+++ b/src/test/jest/results/safari-standard-stats-result.json
@@ -54,6 +54,96 @@
             "totalReceivedPacketsLost": 2,
             "totalSentPacketsLost": 0
           },
+          "tracks": {
+            "receiverTracks": {
+              "1169210963": {
+                "mediaType": "audio",
+                "packets": 874,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "1291750480": {
+                "mediaType": "audio",
+                "packets": 8360,
+                "packetsLost": 1,
+                "packetsLostPct": 0.01,
+                "packetsLostVariance": 0.015147928994082837
+              },
+              "1426121629": {
+                "mediaType": "audio",
+                "packets": 6713,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "2403718901": {
+                "mediaType": "video",
+                "packets": 6922,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "271883463": {
+                "mediaType": "video",
+                "packets": 4005,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "3996408746": {
+                "mediaType": "audio",
+                "packets": 1060,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "4051566705": {
+                "mediaType": "audio",
+                "packets": 10741,
+                "packetsLost": 1,
+                "packetsLostPct": 0.01,
+                "packetsLostVariance": 0.012193263222069844
+              },
+              "876450406": {
+                "mediaType": "audio",
+                "packets": 2013,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "891790093": {
+                "mediaType": "video",
+                "packets": 5858,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "972539169": {
+                "mediaType": "video",
+                "packets": 802,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              }
+            },
+            "senderTracks": {
+              "1449778799": {
+                "mediaType": "audio",
+                "packets": 9452,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              },
+              "2047229442": {
+                "mediaType": "video",
+                "packets": 17080,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0
+              }
+            }
+          },
           "transportAggregates": {
             "meanRtt": 0.05
           }


### PR DESCRIPTION
This PR adds stats calculation for all tracks within a PeerConnection. And calculates the variant for the packet loss.

I decided for now to actually store the tracks inside the PeerConnection object, because I fear otherwise we would need to copy over attributes like the 'isP2P' attribute from the PeerConnection into each of the tracks. But maybe there is a better solution than this.