### PR TITLE
fix: Prevents NULL values in some cases observed in production.

### DIFF
--- a/src/features/quality-stats/QualityStatsCollector.js
+++ b/src/features/quality-stats/QualityStatsCollector.js
@@ -192,6 +192,9 @@ class QualityStatsCollector {
 
         if (inboundVideoSummary && inboundVideoSummary.frameHeight > 0) {
 
+            if (inboundVideoSummary.framesPerSecond === undefined) {
+                inboundVideoSummary.framesPerSecond = 0;
+            }
             // if this report has different frame resolution, we update the principal/secondary resolution/frame rate
             if (!videoExperience.upperBound
                 || videoExperience.upperBound.frameHeight < inboundVideoSummary.frameHeight) {

--- a/src/test/jest/results/safari-standard-stats-result.json
+++ b/src/test/jest/results/safari-standard-stats-result.json
@@ -172,14 +172,6 @@
           },
           "transportAggregates": {
             "meanRtt": 0.05
-          },
-          "inboundVideoExperience": {
-            "upperBoundAggregates": {
-              "meanFrameHeight": 180
-            },
-            "lowerBoundAggregates": {
-              "meanFrameHeight": 180
-            }
           }
         }
       }   

--- a/src/utils/stats-detection.js
+++ b/src/utils/stats-detection.js
@@ -339,14 +339,6 @@ function getInboundVideoSummaryStandard(statsEntry, report) {
             framesPerSecond: report.googFrameRateOutput
         };
     }
-
-    if (report.type === 'track' && report.remoteSource === true && report.frameHeight) {
-        // Found in google-standard-stats-* and safari-standard-stats. Unfortunately it contains cumulative frames, so
-        // no rate that we can extract.
-        return {
-            frameHeight: report.frameHeight
-        };
-    }
 }
 
 


### PR DESCRIPTION
We have observed some NULL entries in the upper/lower bound frame rate fields in Redshift that should have values.

Part of the problem seems to be that we are processing the obsolete 'track' reports. These reports have been replaced by the 'inbound-rtp' reports that we already handle. 

Moreover, we have found some traces in production where the browser doesn't report framesPerSecond for inbound video streams presumably because it's rounded down to 0.

This PR attempts to fix both of these cases.