### PR TITLE
Adds the ssrc in the track metrics table.

### DIFF
--- a/bin/extract.js
+++ b/bin/extract.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // this small command line utility can be used like this
-// aws s3 cp s3://rtcstats-server-bucket/023e3641-6e68-46c0-8c79-5b436b0e41bc.gz - | ./bin/extract.js /dev/stdin
+// aws s3 cp s3://rtcstats-server-bucket/023e3641-6e68-46c0-8c79-5b436b0e41bc.gz - | gunzip | ./bin/extract.js /dev/stdin
 const { EOL } = require('os');
 
 const FeatureExtractor = require('../src/features/FeatureExtractor');

--- a/src/queries/redshift-schema.sql
+++ b/src/queries/redshift-schema.sql
@@ -74,6 +74,7 @@ CREATE TABLE IF NOT EXISTS rtcstats_track_metrics (
     isP2P BOOLEAN,
     direction VARCHAR(128),
     mediaType VARCHAR(128),
+    ssrc BIGINT,
     packets BIGINT,
     packetsLost BIGINT,
     packetsLostPct REAL,

--- a/src/queries/redshift-schema.sql
+++ b/src/queries/redshift-schema.sql
@@ -74,7 +74,8 @@ CREATE TABLE IF NOT EXISTS rtcstats_track_metrics (
     isP2P BOOLEAN,
     direction VARCHAR(128),
     mediaType VARCHAR(128),
-    ssrc BIGINT,
+    /* the ssrc is an unsigned 32 bit integer, so it can never reach 128 characters in length but we define it as such for uniformity */
+    ssrc VARCHAR(128),
     packets BIGINT,
     packetsLost BIGINT,
     packetsLostPct REAL,


### PR DESCRIPTION
This PR adds the rtp stream ssrc (a 32-bit unsigned integer) in the database schema as a BIGINT. It seems that this was forgotten to be added in a50d83b.