### PR TITLE
feat: extract concealed samples and report concealed percentages

### DIFF
--- a/src/database/FirehoseConnector.js
+++ b/src/database/FirehoseConnector.js
@@ -105,7 +105,8 @@ class FirehoseConnector {
             packets,
             packetsLost,
             packetsLostPct,
-            packetsLostVariance
+            packetsLostVariance,
+            concealedPercentage
         } = track;
 
         const id = uuid.v4();
@@ -122,7 +123,8 @@ class FirehoseConnector {
             packets,
             packetsLost,
             packetsLostPct,
-            packetsLostVariance
+            packetsLostVariance,
+            concealedPercentage
         };
 
         this._putRecord(trackSchemaObj, this._trackStatsStream);

--- a/src/features/quality-stats/FirefoxStatsExtractor.js
+++ b/src/features/quality-stats/FirefoxStatsExtractor.js
@@ -73,6 +73,15 @@ class FirefoxStatsExtractor {
     extractInboundVideoSummary(statsEntry, report) {
         return getInboundVideoSummaryFirefox(statsEntry, report);
     }
+
+    /**
+     * Extract the concealed and received samples - so far not supported by Firefox stats :-(
+     *
+     * @returns null - As long as this stat is not supported by Firefox.
+     */
+    extractConcealedSamplesReceived() {
+        return null;
+    }
 }
 
 module.exports = FirefoxStatsExtractor;

--- a/src/features/quality-stats/QualityStatsCollector.js
+++ b/src/features/quality-stats/QualityStatsCollector.js
@@ -167,6 +167,9 @@ class QualityStatsCollector {
         const concealedSamplesReceived = this.statsExtractor.extractConcealedSamplesReceived(statsEntry, report);
 
         if (concealedSamplesReceived) {
+            // As the name totalSamplesReceived suggests, it is an increasing cumulative counter.
+            // But the concealedSamples is also a cumulative counter even though it doesn't have
+            // total in it is name.
             const { ssrc, totalSamples, concealed } = concealedSamplesReceived;
 
             const trackData = this._getTrackData(pcData, ssrc);

--- a/src/features/quality-stats/QualityStatsCollector.js
+++ b/src/features/quality-stats/QualityStatsCollector.js
@@ -17,7 +17,9 @@ function newTrack(ssrc) {
         packetsReceived: [],
         packetsReceivedLost: [],
         packetsSent: [],
-        packetsSentLost: []
+        packetsSentLost: [],
+        totalSamplesReceived: [],
+        concealedSamplesReceived: []
     };
 }
 
@@ -150,6 +152,27 @@ class QualityStatsCollector {
             trackData.mediaType = mediaType;
             trackData.packetsReceivedLost.push(packetsLost);
             trackData.packetsReceived.push(packetsReceived);
+        }
+    }
+
+    /**
+     * Get the samples received and concealed samples metrics from the current report, and push them to the
+     * track to which they belong (based on SSRC).
+     *
+     * @param {Object} pcData- Output param, collected data gets put here.
+     * @param {Object} statsEntry - The complete webrtc statistics entry which contains multiple reports.
+     * @param {Object} report - A single report from a stats entry.
+     */
+    _collectConcealedSamples(pcData, statsEntry, report) {
+        const concealedSamplesReceived = this.statsExtractor.extractConcealedSamplesReceived(statsEntry, report);
+
+        if (concealedSamplesReceived) {
+            const { ssrc, totalSamples, concealed } = concealedSamplesReceived;
+
+            const trackData = this._getTrackData(pcData, ssrc);
+
+            trackData.totalSamplesReceived.push(totalSamples);
+            trackData.concealedSamplesReceived.push(concealed);
         }
     }
 
@@ -483,6 +506,7 @@ class QualityStatsCollector {
             this._collectRttData(rtts, statsEntry, report);
             this._collectIsUsingRelayData(pcData, statsEntry, report);
             this._collectPacketLossData(pcData, statsEntry, report);
+            this._collectConcealedSamples(pcData, statsEntry, report);
             this._updateInboundVideoExperience(inboundVideoExperience, statsEntry, report);
         });
 

--- a/src/features/quality-stats/StandardStatsExtractor.js
+++ b/src/features/quality-stats/StandardStatsExtractor.js
@@ -1,4 +1,4 @@
-const { getRTTStandard, isUsingRelayStandard, getTotalReceivedPacketsStandard,
+const { getRTTStandard, isUsingRelayStandard, getTotalReceivedPacketsStandard, getConcealedSamplesReceivedStandard,
     getTotalSentPacketsStandard, getInboundVideoSummaryStandard } = require('../../utils/stats-detection');
 
 /**
@@ -68,6 +68,17 @@ class StandardStatsExtractor {
      */
     extractInboundVideoSummary(statsEntry, report) {
         return getInboundVideoSummaryStandard(statsEntry, report);
+    }
+
+    /**
+     * Extract statistics for totalSamplesReceived and concealedSamples.
+     *
+     * @param {Object} statsEntry - Complete rtcstats entry.
+     * @param {Object} report - Individual stat report.
+     * @returns {ConcealeadSamplesSummary}
+     */
+    extractConcealedSamplesReceived(statsEntry, report) {
+        return getConcealedSamplesReceivedStandard(statsEntry, report);
     }
 }
 module.exports = StandardStatsExtractor;

--- a/src/queries/redshift-schema.sql
+++ b/src/queries/redshift-schema.sql
@@ -80,6 +80,7 @@ CREATE TABLE IF NOT EXISTS rtcstats_track_metrics (
     packetsLost BIGINT,
     packetsLostPct REAL,
     packetsLostVariance REAL,
+    concealedPercentage REAL,
     PRIMARY KEY(id),
     FOREIGN KEY (pcId) REFERENCES rtcstats_pc_metrics(id)
 )

--- a/src/test/jest/results/59c86272-03ea-42e9-a62d-1c8a272e8ab0.json
+++ b/src/test/jest/results/59c86272-03ea-42e9-a62d-1c8a272e8ab0.json
@@ -32,6 +32,7 @@
                     "tracks": {
                         "receiverTracks": [
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video/camera",
                                 "packets": 4551,
                                 "packetsLost": 0,

--- a/src/test/jest/results/9c93a447-c9f8-489d-87ca-21263dec0642.json
+++ b/src/test/jest/results/9c93a447-c9f8-489d-87ca-21263dec0642.json
@@ -32,6 +32,7 @@
                     "tracks": {
                         "receiverTracks": [
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video/camera",
                                 "packets": 1478,
                                 "packetsLost": 0,
@@ -42,6 +43,7 @@
                         ],
                         "senderTracks": [
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 1100,
                                 "packetsLost": 0,
@@ -86,6 +88,7 @@
                     "tracks": {
                         "receiverTracks": [
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 147,
                                 "packetsLost": 0,
@@ -94,6 +97,7 @@
                                 "ssrc": 1636121229
                             },
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video/camera",
                                 "packets": 810,
                                 "packetsLost": 0,
@@ -102,6 +106,7 @@
                                 "ssrc": 2511181394
                             },
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video/camera",
                                 "packets": 354,
                                 "packetsLost": 0,
@@ -110,6 +115,7 @@
                                 "ssrc": 2683469917
                             },
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video/desktop",
                                 "packets": 464,
                                 "packetsLost": 0,
@@ -120,6 +126,7 @@
                         ],
                         "senderTracks": [
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 1730,
                                 "packetsLost": 0,

--- a/src/test/jest/results/chrome-standard-multiple-p2p.json
+++ b/src/test/jest/results/chrome-standard-multiple-p2p.json
@@ -32,6 +32,7 @@
                     "tracks": {
                         "receiverTracks": [
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 48305,
                                 "packetsLost": 0,
@@ -40,6 +41,7 @@
                                 "ssrc": 2137521633
                             },
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "audio",
                                 "packets": 8918,
                                 "packetsLost": 0,
@@ -50,6 +52,7 @@
                         ],
                         "senderTracks": [
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 48385,
                                 "packetsLost": 0,
@@ -58,6 +61,7 @@
                                 "ssrc": 1620858383
                             },
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "audio",
                                 "packets": 8586,
                                 "packetsLost": 0,
@@ -66,6 +70,7 @@
                                 "ssrc": 2889766682
                             },
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "audio",
                                 "packets": 8918,
                                 "packetsLost": 0,
@@ -162,6 +167,7 @@
                     "tracks": {
                         "receiverTracks": [
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 8888,
                                 "packetsLost": 1,
@@ -170,6 +176,7 @@
                                 "ssrc": 213033406
                             },
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 7705,
                                 "packetsLost": 0,
@@ -178,6 +185,7 @@
                                 "ssrc": 383827991
                             },
                             {
+                                "concealedPercentage": 0.06,
                                 "mediaType": "audio",
                                 "packets": 4812,
                                 "packetsLost": 0,
@@ -186,6 +194,7 @@
                                 "ssrc": 1047537249
                             },
                             {
+                                "concealedPercentage": 0.36,
                                 "mediaType": "audio",
                                 "packets": 4298,
                                 "packetsLost": 0,
@@ -196,6 +205,7 @@
                         ],
                         "senderTracks": [
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 8828,
                                 "packetsLost": 0,
@@ -204,6 +214,7 @@
                                 "ssrc": 439337024
                             },
                             {
+                                "concealedPercentage": 0.06,
                                 "mediaType": "audio",
                                 "packets": 4783,
                                 "packetsLost": 0,
@@ -212,6 +223,7 @@
                                 "ssrc": 1047537249
                             },
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 1628,
                                 "packetsLost": 0,
@@ -220,6 +232,7 @@
                                 "ssrc": 1970267439
                             },
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "audio",
                                 "packets": 5021,
                                 "packetsLost": 0,
@@ -228,6 +241,7 @@
                                 "ssrc": 2178445542
                             },
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 3046,
                                 "packetsLost": 0,
@@ -236,6 +250,7 @@
                                 "ssrc": 3711962879
                             },
                             {
+                                "concealedPercentage": 0.36,
                                 "mediaType": "audio",
                                 "packets": 4254,
                                 "packetsLost": 0,
@@ -280,6 +295,7 @@
                     "tracks": {
                         "receiverTracks": [
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 8824,
                                 "packetsLost": 0,
@@ -288,6 +304,7 @@
                                 "ssrc": 1800846447
                             },
                             {
+                                "concealedPercentage": 0.01,
                                 "mediaType": "audio",
                                 "packets": 1944,
                                 "packetsLost": 0,
@@ -298,6 +315,7 @@
                         ],
                         "senderTracks": [
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 9089,
                                 "packetsLost": 0,
@@ -306,6 +324,7 @@
                                 "ssrc": 75366989
                             },
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "audio",
                                 "packets": 1944,
                                 "packetsLost": 0,
@@ -314,6 +333,7 @@
                                 "ssrc": 2684505137
                             },
                             {
+                                "concealedPercentage": 0.01,
                                 "mediaType": "audio",
                                 "packets": 1802,
                                 "packetsLost": 0,

--- a/src/test/jest/results/chrome-standard-pc-failed.json
+++ b/src/test/jest/results/chrome-standard-pc-failed.json
@@ -32,6 +32,7 @@
                     "tracks": {
                         "receiverTracks": [
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 3976,
                                 "packetsLost": 1,
@@ -40,6 +41,7 @@
                                 "ssrc": 69911005
                             },
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 3985,
                                 "packetsLost": 1,
@@ -50,6 +52,7 @@
                         ],
                         "senderTracks": [
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "audio",
                                 "packets": 3013,
                                 "packetsLost": 0,

--- a/src/test/jest/results/chrome-standard-pc-reconnect.json
+++ b/src/test/jest/results/chrome-standard-pc-reconnect.json
@@ -32,6 +32,7 @@
                     "tracks": {
                         "receiverTracks": [
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 1277,
                                 "packetsLost": 1,
@@ -40,6 +41,7 @@
                                 "ssrc": 69911005
                             },
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "video",
                                 "packets": 1276,
                                 "packetsLost": 1,
@@ -50,6 +52,7 @@
                         ],
                         "senderTracks": [
                             {
+                                "concealedPercentage": 0,
                                 "mediaType": "audio",
                                 "packets": 935,
                                 "packetsLost": 0,

--- a/src/test/jest/results/chrome96-standard-stats-p2p-add-transceiver-result.json
+++ b/src/test/jest/results/chrome96-standard-stats-p2p-add-transceiver-result.json
@@ -79,6 +79,7 @@
           "tracks": {
             "receiverTracks": [
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 977,
                 "packetsLost": 0,
@@ -87,6 +88,7 @@
                 "ssrc": "30949311"
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 3031,
                 "packetsLost": 0,
@@ -97,6 +99,7 @@
             ],
             "senderTracks": [
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 2970,
                 "packetsLost": 0,
@@ -105,6 +108,7 @@
                 "ssrc": "3500323962"
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 977,
                 "packetsLost": 0,
@@ -149,6 +153,7 @@
           "tracks": {
             "receiverTracks": [
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 0,
                 "packetsLost": 0,
@@ -157,6 +162,7 @@
                 "ssrc": "1838074254"
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 33,
                 "packetsLost": 0,
@@ -165,6 +171,7 @@
                 "ssrc": "1993617966"
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 0,
                 "packetsLost": 0,
@@ -173,6 +180,7 @@
                 "ssrc": "2040317954"
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 18,
                 "packetsLost": 0,
@@ -183,6 +191,7 @@
             ],
             "senderTracks": [
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 18,
                 "packetsLost": 0,
@@ -191,6 +200,7 @@
                 "ssrc": "8040383"
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 65,
                 "packetsLost": 0,

--- a/src/test/jest/results/firefox-standard-stats-sfu-result.json
+++ b/src/test/jest/results/firefox-standard-stats-sfu-result.json
@@ -73,6 +73,7 @@
           "tracks": {
             "receiverTracks": [
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 4580,
                 "packetsLost": 0,
@@ -81,6 +82,7 @@
                 "ssrc": 271883463
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 3229,
                 "packetsLost": 0,
@@ -89,6 +91,7 @@
                 "ssrc": 876450406
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 8408,
                 "packetsLost": 1,
@@ -97,6 +100,7 @@
                 "ssrc": 891790093
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 2417,
                 "packetsLost": 0,
@@ -105,6 +109,7 @@
                 "ssrc": 972539169
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 6778,
                 "packetsLost": 3,
@@ -113,6 +118,7 @@
                 "ssrc": 1291750480
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 7683,
                 "packetsLost": 0,
@@ -121,6 +127,7 @@
                 "ssrc": 1426121629
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 6065,
                 "packetsLost": 0,
@@ -129,6 +136,7 @@
                 "ssrc": 1449778799
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 7177,
                 "packetsLost": 1,
@@ -137,6 +145,7 @@
                 "ssrc": 2047229442
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 8352,
                 "packetsLost": 2,
@@ -145,6 +154,7 @@
                 "ssrc": 2403718901
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 7770,
                 "packetsLost": 1,
@@ -155,6 +165,7 @@
             ],
             "senderTracks": [
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 0,
                 "packetsLost": 0,
@@ -163,6 +174,7 @@
                 "ssrc": 271883463
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 0,
                 "packetsLost": 0,

--- a/src/test/jest/results/firefox97-standard-stats-sfu-result.json
+++ b/src/test/jest/results/firefox97-standard-stats-sfu-result.json
@@ -73,6 +73,7 @@
           "tracks": {
             "receiverTracks": [
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 4294906587,
                 "packetsLost": 0,
@@ -81,6 +82,7 @@
                 "ssrc": 275935317
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 12076,
                 "packetsLost": 0,
@@ -89,6 +91,7 @@
                 "ssrc": 420677523
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 2089,
                 "packetsLost": 0,
@@ -97,6 +100,7 @@
                 "ssrc": 676202912
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 3366,
                 "packetsLost": 0,
@@ -105,6 +109,7 @@
                 "ssrc": 2555995057
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 11779,
                 "packetsLost": 28,
@@ -115,6 +120,7 @@
             ],
             "senderTracks": [
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 0,
                 "packetsLost": 0,
@@ -123,6 +129,7 @@
                 "ssrc": 275935317
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 0,
                 "packetsLost": 0,
@@ -131,6 +138,7 @@
                 "ssrc": 420677523
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 0,
                 "packetsLost": 0,

--- a/src/test/jest/results/google-standard-stats-p2p-result.json
+++ b/src/test/jest/results/google-standard-stats-p2p-result.json
@@ -73,6 +73,7 @@
           "tracks": {
             "receiverTracks": [
               {
+                "concealedPercentage": 0.03,
                 "mediaType": "audio",
                 "packets": 2645,
                 "packetsLost": 0,
@@ -81,6 +82,7 @@
                 "ssrc": 250981789
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 9585,
                 "packetsLost": 0,
@@ -91,6 +93,7 @@
             ],
             "senderTracks": [
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 8421,
                 "packetsLost": 0,
@@ -99,6 +102,7 @@
                 "ssrc": 9891702
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 2642,
                 "packetsLost": 0,
@@ -143,6 +147,7 @@
           "tracks": {
             "receiverTracks": [
               {
+                "concealedPercentage": 1.01,
                 "mediaType": "audio",
                 "packets": 1267,
                 "packetsLost": 0,
@@ -151,6 +156,7 @@
                 "ssrc": 757648711
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 738,
                 "packetsLost": 0,
@@ -159,6 +165,7 @@
                 "ssrc": 1030784244
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 1031,
                 "packetsLost": 0,
@@ -167,6 +174,7 @@
                 "ssrc": 1052990334
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 334,
                 "packetsLost": 36,
@@ -175,6 +183,7 @@
                 "ssrc": 1527498116
               },
               {
+                "concealedPercentage": 2.42,
                 "mediaType": "audio",
                 "packets": 354,
                 "packetsLost": 0,
@@ -183,6 +192,7 @@
                 "ssrc": 1661050740
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 39,
                 "packetsLost": 0,
@@ -191,6 +201,7 @@
                 "ssrc": 1845975655
               },
               {
+                "concealedPercentage": 96.87,
                 "mediaType": "audio",
                 "packets": 82,
                 "packetsLost": 0,
@@ -199,6 +210,7 @@
                 "ssrc": 2566963332
               },
               {
+                "concealedPercentage": 47.09,
                 "mediaType": "audio",
                 "packets": 1163,
                 "packetsLost": 0,
@@ -209,6 +221,7 @@
             ],
             "senderTracks": [
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 163,
                 "packetsLost": 0,
@@ -217,6 +230,7 @@
                 "ssrc": 1191903134
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 2905,
                 "packetsLost": 7,
@@ -225,6 +239,7 @@
                 "ssrc": 1409401962
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 2334,
                 "packetsLost": 2,
@@ -233,6 +248,7 @@
                 "ssrc": 2545347749
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 915,
                 "packetsLost": 2,

--- a/src/test/jest/results/google-standard-stats-sfu-result.json
+++ b/src/test/jest/results/google-standard-stats-sfu-result.json
@@ -73,6 +73,7 @@
           "tracks": {
             "receiverTracks": [
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 1898,
                 "packetsLost": 0,
@@ -81,6 +82,7 @@
                 "ssrc": 428706097
               },
               {
+                "concealedPercentage": 27.89,
                 "mediaType": "audio",
                 "packets": 2234,
                 "packetsLost": 0,
@@ -89,6 +91,7 @@
                 "ssrc": 757648711
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 4473,
                 "packetsLost": 2,
@@ -97,6 +100,7 @@
                 "ssrc": 1030784244
               },
               {
+                "concealedPercentage": 0.24,
                 "mediaType": "audio",
                 "packets": 3253,
                 "packetsLost": 0,
@@ -105,6 +109,7 @@
                 "ssrc": 1661050740
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 4385,
                 "packetsLost": 5,
@@ -113,6 +118,7 @@
                 "ssrc": 1845975655
               },
               {
+                "concealedPercentage": 0.79,
                 "mediaType": "audio",
                 "packets": 3252,
                 "packetsLost": 2,
@@ -123,6 +129,7 @@
             ],
             "senderTracks": [
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 2026,
                 "packetsLost": 0,
@@ -131,6 +138,7 @@
                 "ssrc": 1950053863
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 3254,
                 "packetsLost": 0,

--- a/src/test/jest/results/safari-standard-stats-result.json
+++ b/src/test/jest/results/safari-standard-stats-result.json
@@ -73,6 +73,7 @@
           "tracks": {
             "receiverTracks": [
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 4005,
                 "packetsLost": 0,
@@ -81,6 +82,7 @@
                 "ssrc": 271883463
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 2013,
                 "packetsLost": 0,
@@ -89,6 +91,7 @@
                 "ssrc": 876450406
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 5858,
                 "packetsLost": 0,
@@ -97,6 +100,7 @@
                 "ssrc": 891790093
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 802,
                 "packetsLost": 0,
@@ -105,6 +109,7 @@
                 "ssrc": 972539169
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 874,
                 "packetsLost": 0,
@@ -113,6 +118,7 @@
                 "ssrc": 1169210963
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 8360,
                 "packetsLost": 1,
@@ -121,6 +127,7 @@
                 "ssrc": 1291750480
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 6713,
                 "packetsLost": 0,
@@ -129,6 +136,7 @@
                 "ssrc": 1426121629
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 6922,
                 "packetsLost": 0,
@@ -137,6 +145,7 @@
                 "ssrc": 2403718901
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 1060,
                 "packetsLost": 0,
@@ -145,6 +154,7 @@
                 "ssrc": 3996408746
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 10741,
                 "packetsLost": 1,
@@ -155,6 +165,7 @@
             ],
             "senderTracks": [
               {
+                "concealedPercentage": 0,
                 "mediaType": "audio",
                 "packets": 9452,
                 "packetsLost": 0,
@@ -163,6 +174,7 @@
                 "ssrc": 1449778799
               },
               {
+                "concealedPercentage": 0,
                 "mediaType": "video",
                 "packets": 17080,
                 "packetsLost": 0,

--- a/src/utils/stats-detection.js
+++ b/src/utils/stats-detection.js
@@ -313,6 +313,22 @@ function getTotalReceivedPacketsStandard(statsEntry, report) {
     }
 }
 
+/**
+ * Return standard statistics for totalSamplesReceived and concealedSamples.
+ *
+ * @param {Object} statsEntry - Complete rtcstats entry.
+ * @param {Object} report - Individual stat report.
+ * @returns {ConcealeadSamplesSummary}
+ */
+function getConcealedSamplesReceivedStandard(statsEntry, report) {
+    if (report.totalSamplesReceived && report.concealedSamples && report.ssrc) {
+        return {
+            ssrc: report.ssrc,
+            totalSamples: Number(report.totalSamplesReceived) || 0,
+            concealed: Number(report.concealedSamples) || 0
+        };
+    }
+}
 
 /**
  * Return standard statistics for received and lost packets.
@@ -600,6 +616,7 @@ module.exports = {
     getTotalReceivedPacketsStandard,
     getTotalSentPacketsStandard,
     getTotalSentPacketsFirefox,
+    getConcealedSamplesReceivedStandard,
     getInboundVideoSummaryStandard,
     getInboundVideoSummaryFirefox,
     getTransportInfoFn,


### PR DESCRIPTION
This PR adds the feature to extract received and concealed audio samples. These then get aggregated into the concealed percentage and written into the DB.
This should allow us to track how effective RED FEC is going to be in our deployments.