### PR TITLE
feat: Makes it possible to mass update the test results.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint ./src/",
     "integration": "node ./src/test/client.js",
     "test": "jest",
+    "test:fix": "jest ./src/test/jest/extract.test.js -- --fix",
     "start": "NODE_ENV=production node ./src/app.js",
     "watch:dev": "nodemon --exec 'NODE_ENV=debug node ./src/app.js'",
     "debug": "NODE_ENV=debug node ./src/app.js",

--- a/src/test/jest/results/59c86272-03ea-42e9-a62d-1c8a272e8ab0.json
+++ b/src/test/jest/results/59c86272-03ea-42e9-a62d-1c8a272e8ab0.json
@@ -1,128 +1,128 @@
 [
-    {
-        "features": {
-            "aggregates": {
-                "PC_0": {
-                    "connectionFailed": false,
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "iceReconnects": 0,
-                    "inboundVideoExperience": {
-                        "lowerBoundAggregates": {
-                            "meanFrameHeight": 630,
-                            "meanFramesPerSecond": 29.75
-                        },
-                        "upperBoundAggregates": {
-                            "meanFrameHeight": 630,
-                            "meanFramesPerSecond": 29.75
-                        }
-                    },
-                    "isP2P": true,
-                    "lastIceDisconnect": 0,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 41170,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 4551,
-                        "totalPacketsSent": 0,
-                        "totalReceivedPacketsLost": 0,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video/camera",
-                                "packets": 4551,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 3155040392
-                            }
-                        ],
-                        "senderTracks": []
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0
-                    },
-                    "usesRelay": false
-                },
-                "PC_1": {
-                    "connectionFailed": false,
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "iceReconnects": 0,
-                    "isP2P": false,
-                    "lastIceDisconnect": 0,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 41492,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 0,
-                        "totalPacketsSent": 0,
-                        "totalReceivedPacketsLost": 0,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [],
-                        "senderTracks": []
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0.04
-                    },
-                    "usesRelay": false
-                }
+  {
+    "features": {
+      "aggregates": {
+        "PC_0": {
+          "connectionFailed": false,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "inboundVideoExperience": {
+            "lowerBoundAggregates": {
+              "meanFrameHeight": 630,
+              "meanFramesPerSecond": 29.75
             },
-            "browserInfo": {
-                "majorVersion": "100",
-                "name": "Chrome",
-                "nameOs": "Chrome/Windows 10 64-bit",
-                "nameVersion": "Chrome/100.0.4896.127",
-                "nameVersionOs": "Chrome/100.0.4896.127/Windows 10 64-bit",
-                "os": "Windows 10 64-bit",
-                "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
-                "version": "100.0.4896.127"
-            },
-            "deploymentInfo": {
-                "crossRegion": 0,
-                "envType": "dev",
-                "environment": "lonely",
-                "region": "eu-west-1",
-                "releaseNumber": "",
-                "shard": "hcv-lonely-george",
-                "userRegion": ""
-            },
-            "dominantSpeakerChanges": 0,
-            "faceLandmarksTimestamps": [],
-            "metrics": {
-                "conferenceDurationMs": 0,
-                "dsRequestBytes": 0,
-                "dsRequestCount": 0,
-                "dumpFileSizeBytes": 68782,
-                "otherRequestBytes": 15884,
-                "otherRequestCount": 82,
-                "sdpRequestBytes": 2202,
-                "sdpRequestCount": 23,
-                "sentimentRequestBytes": 0,
-                "sentimentRequestCount": 0,
-                "sessionDurationMs": 72071,
-                "statsRequestBytes": 105808,
-                "statsRequestCount": 10,
-                "totalProcessedBytes": 123894,
-                "totalProcessedCount": 115
-            },
-            "sentiment": {
-                "angry": 0,
-                "disgusted": 0,
-                "fearful": 0,
-                "happy": 0,
-                "neutral": 0,
-                "sad": 0,
-                "surprised": 0
-            },
-            "speakerTime": 0
+            "upperBoundAggregates": {
+              "meanFrameHeight": 630,
+              "meanFramesPerSecond": 29.75
+            }
+          },
+          "isP2P": true,
+          "lastIceDisconnect": 0,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 41170,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 4551,
+            "totalPacketsSent": 0,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video/camera",
+                "packets": 4551,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 3155040392
+              }
+            ],
+            "senderTracks": []
+          },
+          "transportAggregates": {
+            "meanRtt": 0
+          },
+          "usesRelay": false
+        },
+        "PC_1": {
+          "connectionFailed": false,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "isP2P": false,
+          "lastIceDisconnect": 0,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 41492,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 0,
+            "totalPacketsSent": 0,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [],
+            "senderTracks": []
+          },
+          "transportAggregates": {
+            "meanRtt": 0.04
+          },
+          "usesRelay": false
         }
+      },
+      "browserInfo": {
+        "majorVersion": "100",
+        "name": "Chrome",
+        "nameOs": "Chrome/Windows 10 64-bit",
+        "nameVersion": "Chrome/100.0.4896.127",
+        "nameVersionOs": "Chrome/100.0.4896.127/Windows 10 64-bit",
+        "os": "Windows 10 64-bit",
+        "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36",
+        "version": "100.0.4896.127"
+      },
+      "deploymentInfo": {
+        "crossRegion": 0,
+        "envType": "dev",
+        "environment": "lonely",
+        "region": "eu-west-1",
+        "releaseNumber": "",
+        "shard": "hcv-lonely-george",
+        "userRegion": ""
+      },
+      "dominantSpeakerChanges": 0,
+      "faceLandmarksTimestamps": [],
+      "metrics": {
+        "conferenceDurationMs": 0,
+        "dsRequestBytes": 0,
+        "dsRequestCount": 0,
+        "dumpFileSizeBytes": 68782,
+        "otherRequestBytes": 15884,
+        "otherRequestCount": 82,
+        "sdpRequestBytes": 2202,
+        "sdpRequestCount": 23,
+        "sentimentRequestBytes": 0,
+        "sentimentRequestCount": 0,
+        "sessionDurationMs": 72071,
+        "statsRequestBytes": 105808,
+        "statsRequestCount": 10,
+        "totalProcessedBytes": 123894,
+        "totalProcessedCount": 115
+      },
+      "sentiment": {
+        "angry": 0,
+        "disgusted": 0,
+        "fearful": 0,
+        "happy": 0,
+        "neutral": 0,
+        "sad": 0,
+        "surprised": 0
+      },
+      "speakerTime": 0
     }
+  }
 ]

--- a/src/test/jest/results/9c93a447-c9f8-489d-87ca-21263dec0642.json
+++ b/src/test/jest/results/9c93a447-c9f8-489d-87ca-21263dec0642.json
@@ -1,195 +1,195 @@
 [
-    {
-        "features": {
-            "aggregates": {
-                "PC_0": {
-                    "connectionFailed": false,
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "iceReconnects": 0,
-                    "inboundVideoExperience": {
-                        "lowerBoundAggregates": {
-                            "meanFrameHeight": 720,
-                            "meanFramesPerSecond": 30
-                        },
-                        "upperBoundAggregates": {
-                            "meanFrameHeight": 720,
-                            "meanFramesPerSecond": 30
-                        }
-                    },
-                    "isP2P": true,
-                    "lastIceDisconnect": 0,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 11900,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 1478,
-                        "totalPacketsSent": 1100,
-                        "totalReceivedPacketsLost": 0,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video/camera",
-                                "packets": 1478,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 446564881
-                            }
-                        ],
-                        "senderTracks": [
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 1100,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 845973563
-                            }
-                        ]
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0
-                    },
-                    "usesRelay": false
-                },
-                "PC_1": {
-                    "connectionFailed": false,
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "iceReconnects": 0,
-                    "inboundVideoExperience": {
-                        "lowerBoundAggregates": {
-                            "meanFrameHeight": 270,
-                            "meanFramesPerSecond": 27
-                        },
-                        "upperBoundAggregates": {
-                            "meanFrameHeight": 705,
-                            "meanFramesPerSecond": 17.5
-                        }
-                    },
-                    "isP2P": false,
-                    "lastIceDisconnect": 0,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 37316,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 1775,
-                        "totalPacketsSent": 1730,
-                        "totalReceivedPacketsLost": 0,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 147,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 1636121229
-                            },
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video/camera",
-                                "packets": 810,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 2511181394
-                            },
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video/camera",
-                                "packets": 354,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 2683469917
-                            },
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video/desktop",
-                                "packets": 464,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 2683469917
-                            }
-                        ],
-                        "senderTracks": [
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 1730,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 1784258627
-                            }
-                        ]
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0.03
-                    },
-                    "usesRelay": false
-                }
+  {
+    "features": {
+      "aggregates": {
+        "PC_0": {
+          "connectionFailed": false,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "inboundVideoExperience": {
+            "lowerBoundAggregates": {
+              "meanFrameHeight": 720,
+              "meanFramesPerSecond": 30
             },
-            "browserInfo": {
-                "majorVersion": "101",
-                "name": "Chrome",
-                "nameOs": "Chrome/OS X 10.15.7 64-bit",
-                "nameVersion": "Chrome/101.0.4951.54",
-                "nameVersionOs": "Chrome/101.0.4951.54/OS X 10.15.7 64-bit",
-                "os": "OS X 10.15.7 64-bit",
-                "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36",
-                "version": "101.0.4951.54"
+            "upperBoundAggregates": {
+              "meanFrameHeight": 720,
+              "meanFramesPerSecond": 30
+            }
+          },
+          "isP2P": true,
+          "lastIceDisconnect": 0,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 11900,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 1478,
+            "totalPacketsSent": 1100,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video/camera",
+                "packets": 1478,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 446564881
+              }
+            ],
+            "senderTracks": [
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 1100,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 845973563
+              }
+            ]
+          },
+          "transportAggregates": {
+            "meanRtt": 0
+          },
+          "usesRelay": false
+        },
+        "PC_1": {
+          "connectionFailed": false,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "inboundVideoExperience": {
+            "lowerBoundAggregates": {
+              "meanFrameHeight": 270,
+              "meanFramesPerSecond": 27
             },
-            "deploymentInfo": {
-                "crossRegion": 0,
-                "envType": "dev",
-                "environment": "lonely",
-                "region": "eu-west-1",
-                "releaseNumber": "",
-                "shard": "hcv-lonely-george",
-                "userRegion": ""
-            },
-            "dominantSpeakerChanges": 0,
-            "faceLandmarksTimestamps": [],
-            "metrics": {
-                "conferenceDurationMs": 0,
-                "dsRequestBytes": 0,
-                "dsRequestCount": 0,
-                "dumpFileSizeBytes": 85270,
-                "otherRequestBytes": 20694,
-                "otherRequestCount": 120,
-                "sdpRequestBytes": 3450,
-                "sdpRequestCount": 36,
-                "sentimentRequestBytes": 0,
-                "sentimentRequestCount": 0,
-                "sessionDurationMs": 39488,
-                "statsRequestBytes": 131644,
-                "statsRequestCount": 6,
-                "totalProcessedBytes": 155788,
-                "totalProcessedCount": 162
-            },
-            "sentiment": {
-                "angry": 0,
-                "disgusted": 0,
-                "fearful": 0,
-                "happy": 0,
-                "neutral": 0,
-                "sad": 0,
-                "surprised": 0
-            },
-            "speakerTime": 0
+            "upperBoundAggregates": {
+              "meanFrameHeight": 705,
+              "meanFramesPerSecond": 17.5
+            }
+          },
+          "isP2P": false,
+          "lastIceDisconnect": 0,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 37316,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 1775,
+            "totalPacketsSent": 1730,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 147,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 1636121229
+              },
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video/camera",
+                "packets": 810,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 2511181394
+              },
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video/camera",
+                "packets": 354,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 2683469917
+              },
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video/desktop",
+                "packets": 464,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 2683469917
+              }
+            ],
+            "senderTracks": [
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 1730,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 1784258627
+              }
+            ]
+          },
+          "transportAggregates": {
+            "meanRtt": 0.03
+          },
+          "usesRelay": false
         }
+      },
+      "browserInfo": {
+        "majorVersion": "101",
+        "name": "Chrome",
+        "nameOs": "Chrome/OS X 10.15.7 64-bit",
+        "nameVersion": "Chrome/101.0.4951.54",
+        "nameVersionOs": "Chrome/101.0.4951.54/OS X 10.15.7 64-bit",
+        "os": "OS X 10.15.7 64-bit",
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36",
+        "version": "101.0.4951.54"
+      },
+      "deploymentInfo": {
+        "crossRegion": 0,
+        "envType": "dev",
+        "environment": "lonely",
+        "region": "eu-west-1",
+        "releaseNumber": "",
+        "shard": "hcv-lonely-george",
+        "userRegion": ""
+      },
+      "dominantSpeakerChanges": 0,
+      "faceLandmarksTimestamps": [],
+      "metrics": {
+        "conferenceDurationMs": 0,
+        "dsRequestBytes": 0,
+        "dsRequestCount": 0,
+        "dumpFileSizeBytes": 85270,
+        "otherRequestBytes": 20694,
+        "otherRequestCount": 120,
+        "sdpRequestBytes": 3450,
+        "sdpRequestCount": 36,
+        "sentimentRequestBytes": 0,
+        "sentimentRequestCount": 0,
+        "sessionDurationMs": 39488,
+        "statsRequestBytes": 131644,
+        "statsRequestCount": 6,
+        "totalProcessedBytes": 155788,
+        "totalProcessedCount": 162
+      },
+      "sentiment": {
+        "angry": 0,
+        "disgusted": 0,
+        "fearful": 0,
+        "happy": 0,
+        "neutral": 0,
+        "sad": 0,
+        "surprised": 0
+      },
+      "speakerTime": 0
     }
+  }
 ]

--- a/src/test/jest/results/chrome-standard-multiple-p2p.json
+++ b/src/test/jest/results/chrome-standard-multiple-p2p.json
@@ -1,454 +1,454 @@
 [
-    {
-        "features": {
-            "aggregates": {
-                "PC_0": {
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "inboundVideoExperience": {
-                        "lowerBoundAggregates": {
-                            "meanFrameHeight": 690,
-                            "meanFramesPerSecond": 29.67
-                        },
-                        "upperBoundAggregates": {
-                            "meanFrameHeight": 690,
-                            "meanFramesPerSecond": 29.67
-                        }
-                    },
-                    "isP2P": true,
-                    "lastIceDisconnect": 0,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 181770,
-                    "connectionFailed": false,
-                    "iceReconnects": 0,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 57223,
-                        "totalPacketsSent": 65889,
-                        "totalReceivedPacketsLost": 0,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 48305,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 2137521633
-                            },
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "audio",
-                                "packets": 8918,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 2889766682
-                            }
-                        ],
-                        "senderTracks": [
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 48385,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 1620858383
-                            },
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "audio",
-                                "packets": 8586,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 2889766682
-                            },
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "audio",
-                                "packets": 8918,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 4064199265
-                            }
-                        ]
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0
-                    },
-                    "usesRelay": false
-                },
-                "PC_1": {
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "isP2P": null,
-                    "lastIceDisconnect": 1647251307091,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 0,
-                    "connectionFailed": true,
-                    "iceReconnects": 0,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 0,
-                        "totalPacketsSent": 0,
-                        "totalReceivedPacketsLost": 0,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [],
-                        "senderTracks": []
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0
-                    },
-                    "usesRelay": null
-                },
-                "PC_2": {
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "isP2P": null,
-                    "lastIceDisconnect": 1647251307091,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 0,
-                    "connectionFailed": true,
-                    "iceReconnects": 0,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 0,
-                        "totalPacketsSent": 0,
-                        "totalReceivedPacketsLost": 0,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [],
-                        "senderTracks": []
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0
-                    },
-                    "usesRelay": null
-                },
-                "PC_3": {
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "connectionFailed": false,
-                    "iceReconnects": 0,
-                    "inboundVideoExperience": {
-                        "lowerBoundAggregates": {
-                            "meanFrameHeight": 396,
-                            "meanFramesPerSecond": 29.4
-                        },
-                        "upperBoundAggregates": {
-                            "meanFrameHeight": 396,
-                            "meanFramesPerSecond": 29.7
-                        }
-                    },
-                    "isP2P": false,
-                    "lastIceDisconnect": 0,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 323712,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 25703,
-                        "totalPacketsSent": 27560,
-                        "totalReceivedPacketsLost": 1,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 8888,
-                                "packetsLost": 1,
-                                "packetsLostPct": 0.01,
-                                "packetsLostVariance": 0.09876543209876543,
-                                "ssrc": 213033406
-                            },
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 7705,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 383827991
-                            },
-                            {
-                                "concealedPercentage": 0.06,
-                                "mediaType": "audio",
-                                "packets": 4812,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 1047537249
-                            },
-                            {
-                                "concealedPercentage": 0.36,
-                                "mediaType": "audio",
-                                "packets": 4298,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 3890837313
-                            }
-                        ],
-                        "senderTracks": [
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 8828,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 439337024
-                            },
-                            {
-                                "concealedPercentage": 0.06,
-                                "mediaType": "audio",
-                                "packets": 4783,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 1047537249
-                            },
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 1628,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 1970267439
-                            },
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "audio",
-                                "packets": 5021,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 2178445542
-                            },
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 3046,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 3711962879
-                            },
-                            {
-                                "concealedPercentage": 0.36,
-                                "mediaType": "audio",
-                                "packets": 4254,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 3890837313
-                            }
-                        ]
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0.19
-                    },
-                    "usesRelay": false
-                },
-                "PC_4": {
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "inboundVideoExperience": {
-                        "lowerBoundAggregates": {
-                            "meanFrameHeight": 585,
-                            "meanFramesPerSecond": 30
-                        },
-                        "upperBoundAggregates": {
-                            "meanFrameHeight": 585,
-                            "meanFramesPerSecond": 30
-                        }
-                    },
-                    "isP2P": true,
-                    "lastIceDisconnect": 0,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 40658,
-                    "connectionFailed": false,
-                    "iceReconnects": 0,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 10768,
-                        "totalPacketsSent": 12835,
-                        "totalReceivedPacketsLost": 0,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 8824,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 1800846447
-                            },
-                            {
-                                "concealedPercentage": 0.01,
-                                "mediaType": "audio",
-                                "packets": 1944,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 4223390196
-                            }
-                        ],
-                        "senderTracks": [
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 9089,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 75366989
-                            },
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "audio",
-                                "packets": 1944,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 2684505137
-                            },
-                            {
-                                "concealedPercentage": 0.01,
-                                "mediaType": "audio",
-                                "packets": 1802,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 4223390196
-                            }
-                        ]
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0
-                    },
-                    "usesRelay": false
-                },
-                "PC_5": {
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "isP2P": null,
-                    "lastIceDisconnect": 1647251589613,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 0,
-                    "connectionFailed": true,
-                    "iceReconnects": 0,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 0,
-                        "totalPacketsSent": 0,
-                        "totalReceivedPacketsLost": 0,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [],
-                        "senderTracks": []
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0
-                    },
-                    "usesRelay": null
-                },
-                "PC_6": {
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "isP2P": null,
-                    "lastIceDisconnect": 1647251589613,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 0,
-                    "connectionFailed": true,
-                    "iceReconnects": 0,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 0,
-                        "totalPacketsSent": 0,
-                        "totalReceivedPacketsLost": 0,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [],
-                        "senderTracks": []
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0
-                    },
-                    "usesRelay": null
-                }
+  {
+    "features": {
+      "aggregates": {
+        "PC_0": {
+          "connectionFailed": false,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "inboundVideoExperience": {
+            "lowerBoundAggregates": {
+              "meanFrameHeight": 690,
+              "meanFramesPerSecond": 29.67
             },
-            "browserInfo": {
-                "majorVersion": "99",
-                "name": "Chrome",
-                "nameOs": "Chrome/Windows 10 64-bit",
-                "nameVersion": "Chrome/99.0.4844.51",
-                "nameVersionOs": "Chrome/99.0.4844.51/Windows 10 64-bit",
-                "os": "Windows 10 64-bit",
-                "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36",
-                "version": "99.0.4844.51"
+            "upperBoundAggregates": {
+              "meanFrameHeight": 690,
+              "meanFramesPerSecond": 29.67
+            }
+          },
+          "isP2P": true,
+          "lastIceDisconnect": 0,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 181770,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 57223,
+            "totalPacketsSent": 65889,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 48305,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 2137521633
+              },
+              {
+                "concealedPercentage": 0,
+                "mediaType": "audio",
+                "packets": 8918,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 2889766682
+              }
+            ],
+            "senderTracks": [
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 48385,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 1620858383
+              },
+              {
+                "concealedPercentage": 0,
+                "mediaType": "audio",
+                "packets": 8586,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 2889766682
+              },
+              {
+                "concealedPercentage": 0,
+                "mediaType": "audio",
+                "packets": 8918,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 4064199265
+              }
+            ]
+          },
+          "transportAggregates": {
+            "meanRtt": 0
+          },
+          "usesRelay": false
+        },
+        "PC_1": {
+          "connectionFailed": true,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "isP2P": null,
+          "lastIceDisconnect": 1647251307091,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 0,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 0,
+            "totalPacketsSent": 0,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [],
+            "senderTracks": []
+          },
+          "transportAggregates": {
+            "meanRtt": 0
+          },
+          "usesRelay": null
+        },
+        "PC_2": {
+          "connectionFailed": true,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "isP2P": null,
+          "lastIceDisconnect": 1647251307091,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 0,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 0,
+            "totalPacketsSent": 0,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [],
+            "senderTracks": []
+          },
+          "transportAggregates": {
+            "meanRtt": 0
+          },
+          "usesRelay": null
+        },
+        "PC_3": {
+          "connectionFailed": false,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "inboundVideoExperience": {
+            "lowerBoundAggregates": {
+              "meanFrameHeight": 396,
+              "meanFramesPerSecond": 29.4
             },
-            "deploymentInfo": {
-                "crossRegion": 0,
-                "envType": "dev",
-                "environment": "alpha",
-                "region": "us-west-2",
-                "releaseNumber": "",
-                "shard": "all",
-                "userRegion": ""
+            "upperBoundAggregates": {
+              "meanFrameHeight": 396,
+              "meanFramesPerSecond": 29.7
+            }
+          },
+          "isP2P": false,
+          "lastIceDisconnect": 0,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 323712,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 25703,
+            "totalPacketsSent": 27560,
+            "totalReceivedPacketsLost": 1,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 8888,
+                "packetsLost": 1,
+                "packetsLostPct": 0.01,
+                "packetsLostVariance": 0.09876543209876543,
+                "ssrc": 213033406
+              },
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 7705,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 383827991
+              },
+              {
+                "concealedPercentage": 0.06,
+                "mediaType": "audio",
+                "packets": 4812,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 1047537249
+              },
+              {
+                "concealedPercentage": 0.36,
+                "mediaType": "audio",
+                "packets": 4298,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 3890837313
+              }
+            ],
+            "senderTracks": [
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 8828,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 439337024
+              },
+              {
+                "concealedPercentage": 0.06,
+                "mediaType": "audio",
+                "packets": 4783,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 1047537249
+              },
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 1628,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 1970267439
+              },
+              {
+                "concealedPercentage": 0,
+                "mediaType": "audio",
+                "packets": 5021,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 2178445542
+              },
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 3046,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 3711962879
+              },
+              {
+                "concealedPercentage": 0.36,
+                "mediaType": "audio",
+                "packets": 4254,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 3890837313
+              }
+            ]
+          },
+          "transportAggregates": {
+            "meanRtt": 0.19
+          },
+          "usesRelay": false
+        },
+        "PC_4": {
+          "connectionFailed": false,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "inboundVideoExperience": {
+            "lowerBoundAggregates": {
+              "meanFrameHeight": 585,
+              "meanFramesPerSecond": 30
             },
-            "dominantSpeakerChanges": 1,
-            "faceLandmarksTimestamps": [],
-            "metrics": {
-                "conferenceDurationMs": 0,
-                "dsRequestBytes": 198,
-                "dsRequestCount": 1,
-                "dumpFileSizeBytes": 535931,
-                "otherRequestBytes": 68956,
-                "otherRequestCount": 410,
-                "sdpRequestBytes": 6660,
-                "sdpRequestCount": 70,
-                "sentimentRequestBytes": 0,
-                "sentimentRequestCount": 0,
-                "sessionDurationMs": 325201,
-                "statsRequestBytes": 977330,
-                "statsRequestCount": 129,
-                "totalProcessedBytes": 1053144,
-                "totalProcessedCount": 610
-            },
-            "sentiment": {
-                "angry": 0,
-                "disgusted": 0,
-                "fearful": 0,
-                "happy": 0,
-                "neutral": 0,
-                "sad": 0,
-                "surprised": 0
-            },
-            "speakerTime": 323485
+            "upperBoundAggregates": {
+              "meanFrameHeight": 585,
+              "meanFramesPerSecond": 30
+            }
+          },
+          "isP2P": true,
+          "lastIceDisconnect": 0,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 40658,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 10768,
+            "totalPacketsSent": 12835,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 8824,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 1800846447
+              },
+              {
+                "concealedPercentage": 0.01,
+                "mediaType": "audio",
+                "packets": 1944,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 4223390196
+              }
+            ],
+            "senderTracks": [
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 9089,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 75366989
+              },
+              {
+                "concealedPercentage": 0,
+                "mediaType": "audio",
+                "packets": 1944,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 2684505137
+              },
+              {
+                "concealedPercentage": 0.01,
+                "mediaType": "audio",
+                "packets": 1802,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 4223390196
+              }
+            ]
+          },
+          "transportAggregates": {
+            "meanRtt": 0
+          },
+          "usesRelay": false
+        },
+        "PC_5": {
+          "connectionFailed": true,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "isP2P": null,
+          "lastIceDisconnect": 1647251589613,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 0,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 0,
+            "totalPacketsSent": 0,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [],
+            "senderTracks": []
+          },
+          "transportAggregates": {
+            "meanRtt": 0
+          },
+          "usesRelay": null
+        },
+        "PC_6": {
+          "connectionFailed": true,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "isP2P": null,
+          "lastIceDisconnect": 1647251589613,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 0,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 0,
+            "totalPacketsSent": 0,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [],
+            "senderTracks": []
+          },
+          "transportAggregates": {
+            "meanRtt": 0
+          },
+          "usesRelay": null
         }
+      },
+      "browserInfo": {
+        "majorVersion": "99",
+        "name": "Chrome",
+        "nameOs": "Chrome/Windows 10 64-bit",
+        "nameVersion": "Chrome/99.0.4844.51",
+        "nameVersionOs": "Chrome/99.0.4844.51/Windows 10 64-bit",
+        "os": "Windows 10 64-bit",
+        "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36",
+        "version": "99.0.4844.51"
+      },
+      "deploymentInfo": {
+        "crossRegion": 0,
+        "envType": "dev",
+        "environment": "alpha",
+        "region": "us-west-2",
+        "releaseNumber": "",
+        "shard": "all",
+        "userRegion": ""
+      },
+      "dominantSpeakerChanges": 1,
+      "faceLandmarksTimestamps": [],
+      "metrics": {
+        "conferenceDurationMs": 0,
+        "dsRequestBytes": 198,
+        "dsRequestCount": 1,
+        "dumpFileSizeBytes": 535931,
+        "otherRequestBytes": 68956,
+        "otherRequestCount": 410,
+        "sdpRequestBytes": 6660,
+        "sdpRequestCount": 70,
+        "sentimentRequestBytes": 0,
+        "sentimentRequestCount": 0,
+        "sessionDurationMs": 325201,
+        "statsRequestBytes": 977330,
+        "statsRequestCount": 129,
+        "totalProcessedBytes": 1053144,
+        "totalProcessedCount": 610
+      },
+      "sentiment": {
+        "angry": 0,
+        "disgusted": 0,
+        "fearful": 0,
+        "happy": 0,
+        "neutral": 0,
+        "sad": 0,
+        "surprised": 0
+      },
+      "speakerTime": 323485
     }
+  }
 ]

--- a/src/test/jest/results/chrome-standard-pc-failed.json
+++ b/src/test/jest/results/chrome-standard-pc-failed.json
@@ -1,173 +1,173 @@
 [
-    {
-        "features": {
-            "aggregates": {
-                "PC_0": {
-                    "connectionFailed": true,
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "iceReconnects": 0,
-                    "inboundVideoExperience": {
-                        "lowerBoundAggregates": {
-                            "meanFrameHeight": 360,
-                            "meanFramesPerSecond": 29.33
-                        },
-                        "upperBoundAggregates": {
-                            "meanFrameHeight": 360,
-                            "meanFramesPerSecond": 29.5
-                        }
-                    },
-                    "isP2P": false,
-                    "lastIceDisconnect": 0,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 14211,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0.03,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 7961,
-                        "totalPacketsSent": 3013,
-                        "totalReceivedPacketsLost": 2,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 3976,
-                                "packetsLost": 1,
-                                "packetsLostPct": 0.03,
-                                "packetsLostVariance": 0,
-                                "ssrc": 69911005
-                            },
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 3985,
-                                "packetsLost": 1,
-                                "packetsLostPct": 0.03,
-                                "packetsLostVariance": 0,
-                                "ssrc": 1744315986
-                            }
-                        ],
-                        "senderTracks": [
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "audio",
-                                "packets": 3013,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 2541556871
-                            }
-                        ]
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0.19
-                    },
-                    "usesRelay": false
-                },
-                "PC_1": {
-                    "connectionFailed": true,
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "iceReconnects": 0,
-                    "isP2P": null,
-                    "lastIceDisconnect": 1647265227269,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 0,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 0,
-                        "totalPacketsSent": 0,
-                        "totalReceivedPacketsLost": 0,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [],
-                        "senderTracks": []
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0
-                    },
-                    "usesRelay": null
-                },
-                "PC_2": {
-                    "connectionFailed": true,
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "iceReconnects": 0,
-                    "isP2P": null,
-                    "lastIceDisconnect": 1647265227269,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 0,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 0,
-                        "totalPacketsSent": 0,
-                        "totalReceivedPacketsLost": 0,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [],
-                        "senderTracks": []
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0
-                    },
-                    "usesRelay": null
-                }
+  {
+    "features": {
+      "aggregates": {
+        "PC_0": {
+          "connectionFailed": true,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "inboundVideoExperience": {
+            "lowerBoundAggregates": {
+              "meanFrameHeight": 360,
+              "meanFramesPerSecond": 29.33
             },
-            "browserInfo": {
-                "majorVersion": "99",
-                "name": "Chrome",
-                "nameOs": "Chrome/Windows 10 64-bit",
-                "nameVersion": "Chrome/99.0.4844.51",
-                "nameVersionOs": "Chrome/99.0.4844.51/Windows 10 64-bit",
-                "os": "Windows 10 64-bit",
-                "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36",
-                "version": "99.0.4844.51"
-            },
-            "deploymentInfo": {
-                "crossRegion": 0,
-                "envType": "dev",
-                "environment": "alpha",
-                "region": "us-west-2",
-                "releaseNumber": "",
-                "shard": "all",
-                "userRegion": ""
-            },
-            "dominantSpeakerChanges": 0,
-            "faceLandmarksTimestamps": [],
-            "metrics": {
-                "conferenceDurationMs": 0,
-                "dsRequestBytes": 198,
-                "dsRequestCount": 1,
-                "dumpFileSizeBytes": 101792,
-                "otherRequestBytes": 27294,
-                "otherRequestCount": 166,
-                "sdpRequestBytes": 1682,
-                "sdpRequestCount": 18,
-                "sentimentRequestBytes": 0,
-                "sentimentRequestCount": 0,
-                "sessionDurationMs": 108230,
-                "statsRequestBytes": 160976,
-                "statsRequestCount": 19,
-                "totalProcessedBytes": 190150,
-                "totalProcessedCount": 204
-            },
-            "sentiment": {
-                "angry": 0,
-                "disgusted": 0,
-                "fearful": 0,
-                "happy": 0,
-                "neutral": 0,
-                "sad": 0,
-                "surprised": 0
-            },
-            "speakerTime": 0
+            "upperBoundAggregates": {
+              "meanFrameHeight": 360,
+              "meanFramesPerSecond": 29.5
+            }
+          },
+          "isP2P": false,
+          "lastIceDisconnect": 0,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 14211,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0.03,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 7961,
+            "totalPacketsSent": 3013,
+            "totalReceivedPacketsLost": 2,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 3976,
+                "packetsLost": 1,
+                "packetsLostPct": 0.03,
+                "packetsLostVariance": 0,
+                "ssrc": 69911005
+              },
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 3985,
+                "packetsLost": 1,
+                "packetsLostPct": 0.03,
+                "packetsLostVariance": 0,
+                "ssrc": 1744315986
+              }
+            ],
+            "senderTracks": [
+              {
+                "concealedPercentage": 0,
+                "mediaType": "audio",
+                "packets": 3013,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 2541556871
+              }
+            ]
+          },
+          "transportAggregates": {
+            "meanRtt": 0.19
+          },
+          "usesRelay": false
+        },
+        "PC_1": {
+          "connectionFailed": true,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "isP2P": null,
+          "lastIceDisconnect": 1647265227269,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 0,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 0,
+            "totalPacketsSent": 0,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [],
+            "senderTracks": []
+          },
+          "transportAggregates": {
+            "meanRtt": 0
+          },
+          "usesRelay": null
+        },
+        "PC_2": {
+          "connectionFailed": true,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "isP2P": null,
+          "lastIceDisconnect": 1647265227269,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 0,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 0,
+            "totalPacketsSent": 0,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [],
+            "senderTracks": []
+          },
+          "transportAggregates": {
+            "meanRtt": 0
+          },
+          "usesRelay": null
         }
+      },
+      "browserInfo": {
+        "majorVersion": "99",
+        "name": "Chrome",
+        "nameOs": "Chrome/Windows 10 64-bit",
+        "nameVersion": "Chrome/99.0.4844.51",
+        "nameVersionOs": "Chrome/99.0.4844.51/Windows 10 64-bit",
+        "os": "Windows 10 64-bit",
+        "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36",
+        "version": "99.0.4844.51"
+      },
+      "deploymentInfo": {
+        "crossRegion": 0,
+        "envType": "dev",
+        "environment": "alpha",
+        "region": "us-west-2",
+        "releaseNumber": "",
+        "shard": "all",
+        "userRegion": ""
+      },
+      "dominantSpeakerChanges": 0,
+      "faceLandmarksTimestamps": [],
+      "metrics": {
+        "conferenceDurationMs": 0,
+        "dsRequestBytes": 198,
+        "dsRequestCount": 1,
+        "dumpFileSizeBytes": 101792,
+        "otherRequestBytes": 27294,
+        "otherRequestCount": 166,
+        "sdpRequestBytes": 1682,
+        "sdpRequestCount": 18,
+        "sentimentRequestBytes": 0,
+        "sentimentRequestCount": 0,
+        "sessionDurationMs": 108230,
+        "statsRequestBytes": 160976,
+        "statsRequestCount": 19,
+        "totalProcessedBytes": 190150,
+        "totalProcessedCount": 204
+      },
+      "sentiment": {
+        "angry": 0,
+        "disgusted": 0,
+        "fearful": 0,
+        "happy": 0,
+        "neutral": 0,
+        "sad": 0,
+        "surprised": 0
+      },
+      "speakerTime": 0
     }
+  }
 ]

--- a/src/test/jest/results/chrome-standard-pc-reconnect.json
+++ b/src/test/jest/results/chrome-standard-pc-reconnect.json
@@ -1,173 +1,173 @@
 [
-    {
-        "features": {
-            "aggregates": {
-                "PC_0": {
-                    "connectionFailed": true,
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "inboundVideoExperience": {
-                        "lowerBoundAggregates": {
-                            "meanFrameHeight": 360,
-                            "meanFramesPerSecond": 30
-                        },
-                        "upperBoundAggregates": {
-                            "meanFrameHeight": 360,
-                            "meanFramesPerSecond": 30.5
-                        }
-                    },
-                    "isP2P": false,
-                    "lastIceDisconnect": 0,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 94138,
-                    "iceReconnects": 2,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0.08,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 2553,
-                        "totalPacketsSent": 935,
-                        "totalReceivedPacketsLost": 2,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 1277,
-                                "packetsLost": 1,
-                                "packetsLostPct": 0.08,
-                                "packetsLostVariance": 0,
-                                "ssrc": 69911005
-                            },
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "video",
-                                "packets": 1276,
-                                "packetsLost": 1,
-                                "packetsLostPct": 0.08,
-                                "packetsLostVariance": 0,
-                                "ssrc": 1744315986
-                            }
-                        ],
-                        "senderTracks": [
-                            {
-                                "concealedPercentage": 0,
-                                "mediaType": "audio",
-                                "packets": 935,
-                                "packetsLost": 0,
-                                "packetsLostPct": 0,
-                                "packetsLostVariance": 0,
-                                "ssrc": 935896327
-                            }
-                        ]
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0.19
-                    },
-                    "usesRelay": false
-                },
-                "PC_1": {
-                    "connectionFailed": true,
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "isP2P": null,
-                    "lastIceDisconnect": 1647265416870,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 0,
-                    "iceReconnects": 0,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 0,
-                        "totalPacketsSent": 0,
-                        "totalReceivedPacketsLost": 0,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [],
-                        "senderTracks": []
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0
-                    },
-                    "usesRelay": null
-                },
-                "PC_2": {
-                    "connectionFailed": true,
-                    "dtlsErrors": 0,
-                    "dtlsFailure": 0,
-                    "isP2P": null,
-                    "lastIceDisconnect": 1647265416870,
-                    "lastIceFailure": 0,
-                    "pcSessionDurationMs": 0,
-                    "iceReconnects": 0,
-                    "trackAggregates": {
-                        "receivedPacketsLostPct": 0,
-                        "sentPacketsLostPct": 0,
-                        "totalPacketsReceived": 0,
-                        "totalPacketsSent": 0,
-                        "totalReceivedPacketsLost": 0,
-                        "totalSentPacketsLost": 0
-                    },
-                    "tracks": {
-                        "receiverTracks": [],
-                        "senderTracks": []
-                    },
-                    "transportAggregates": {
-                        "meanRtt": 0
-                    },
-                    "usesRelay": null
-                }
+  {
+    "features": {
+      "aggregates": {
+        "PC_0": {
+          "connectionFailed": true,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 2,
+          "inboundVideoExperience": {
+            "lowerBoundAggregates": {
+              "meanFrameHeight": 360,
+              "meanFramesPerSecond": 30
             },
-            "browserInfo": {
-                "majorVersion": "99",
-                "name": "Chrome",
-                "nameOs": "Chrome/Windows 10 64-bit",
-                "nameVersion": "Chrome/99.0.4844.51",
-                "nameVersionOs": "Chrome/99.0.4844.51/Windows 10 64-bit",
-                "os": "Windows 10 64-bit",
-                "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36",
-                "version": "99.0.4844.51"
-            },
-            "deploymentInfo": {
-                "crossRegion": 0,
-                "envType": "dev",
-                "environment": "alpha",
-                "region": "us-west-2",
-                "releaseNumber": "",
-                "shard": "all",
-                "userRegion": ""
-            },
-            "dominantSpeakerChanges": 0,
-            "faceLandmarksTimestamps": [],
-            "metrics": {
-                "conferenceDurationMs": 0,
-                "dsRequestBytes": 198,
-                "dsRequestCount": 1,
-                "dumpFileSizeBytes": 76745,
-                "otherRequestBytes": 28578,
-                "otherRequestCount": 170,
-                "sdpRequestBytes": 1970,
-                "sdpRequestCount": 21,
-                "sentimentRequestBytes": 0,
-                "sentimentRequestCount": 0,
-                "sessionDurationMs": 95492,
-                "statsRequestBytes": 108714,
-                "statsRequestCount": 7,
-                "totalProcessedBytes": 139460,
-                "totalProcessedCount": 199
-            },
-            "sentiment": {
-                "angry": 0,
-                "disgusted": 0,
-                "fearful": 0,
-                "happy": 0,
-                "neutral": 0,
-                "sad": 0,
-                "surprised": 0
-            },
-            "speakerTime": 0
+            "upperBoundAggregates": {
+              "meanFrameHeight": 360,
+              "meanFramesPerSecond": 30.5
+            }
+          },
+          "isP2P": false,
+          "lastIceDisconnect": 0,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 94138,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0.08,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 2553,
+            "totalPacketsSent": 935,
+            "totalReceivedPacketsLost": 2,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 1277,
+                "packetsLost": 1,
+                "packetsLostPct": 0.08,
+                "packetsLostVariance": 0,
+                "ssrc": 69911005
+              },
+              {
+                "concealedPercentage": 0,
+                "mediaType": "video",
+                "packets": 1276,
+                "packetsLost": 1,
+                "packetsLostPct": 0.08,
+                "packetsLostVariance": 0,
+                "ssrc": 1744315986
+              }
+            ],
+            "senderTracks": [
+              {
+                "concealedPercentage": 0,
+                "mediaType": "audio",
+                "packets": 935,
+                "packetsLost": 0,
+                "packetsLostPct": 0,
+                "packetsLostVariance": 0,
+                "ssrc": 935896327
+              }
+            ]
+          },
+          "transportAggregates": {
+            "meanRtt": 0.19
+          },
+          "usesRelay": false
+        },
+        "PC_1": {
+          "connectionFailed": true,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "isP2P": null,
+          "lastIceDisconnect": 1647265416870,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 0,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 0,
+            "totalPacketsSent": 0,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [],
+            "senderTracks": []
+          },
+          "transportAggregates": {
+            "meanRtt": 0
+          },
+          "usesRelay": null
+        },
+        "PC_2": {
+          "connectionFailed": true,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "isP2P": null,
+          "lastIceDisconnect": 1647265416870,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 0,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 0,
+            "totalPacketsSent": 0,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [],
+            "senderTracks": []
+          },
+          "transportAggregates": {
+            "meanRtt": 0
+          },
+          "usesRelay": null
         }
+      },
+      "browserInfo": {
+        "majorVersion": "99",
+        "name": "Chrome",
+        "nameOs": "Chrome/Windows 10 64-bit",
+        "nameVersion": "Chrome/99.0.4844.51",
+        "nameVersionOs": "Chrome/99.0.4844.51/Windows 10 64-bit",
+        "os": "Windows 10 64-bit",
+        "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36",
+        "version": "99.0.4844.51"
+      },
+      "deploymentInfo": {
+        "crossRegion": 0,
+        "envType": "dev",
+        "environment": "alpha",
+        "region": "us-west-2",
+        "releaseNumber": "",
+        "shard": "all",
+        "userRegion": ""
+      },
+      "dominantSpeakerChanges": 0,
+      "faceLandmarksTimestamps": [],
+      "metrics": {
+        "conferenceDurationMs": 0,
+        "dsRequestBytes": 198,
+        "dsRequestCount": 1,
+        "dumpFileSizeBytes": 76745,
+        "otherRequestBytes": 28578,
+        "otherRequestCount": 170,
+        "sdpRequestBytes": 1970,
+        "sdpRequestCount": 21,
+        "sentimentRequestBytes": 0,
+        "sentimentRequestCount": 0,
+        "sessionDurationMs": 95492,
+        "statsRequestBytes": 108714,
+        "statsRequestCount": 7,
+        "totalProcessedBytes": 139460,
+        "totalProcessedCount": 199
+      },
+      "sentiment": {
+        "angry": 0,
+        "disgusted": 0,
+        "fearful": 0,
+        "happy": 0,
+        "neutral": 0,
+        "sad": 0,
+        "surprised": 0
+      },
+      "speakerTime": 0
     }
+  }
 ]

--- a/src/test/jest/results/chrome96-standard-stats-p2p-add-transceiver-result.json
+++ b/src/test/jest/results/chrome96-standard-stats-p2p-add-transceiver-result.json
@@ -1,91 +1,46 @@
 [
   {
     "dumpInfo": {
+      "ampDeviceId": "8520fd54-ab35-4a4c-9454-45e17605914e",
+      "ampSessionId": 1641601089490,
       "app": "Integration Test",
       "clientId": "bac9ca22-8c8f-45a4-92a2-a3411cfe398a",
       "conferenceUrl": "192.168.1.1/conf-bac9ca22-8c8f-45a4-92a2-a3411cfe398a",
       "dumpPath": "/Users/nohlmeier/src/rtcstats-server/temp/bac9ca22-8c8f-45a4-92a2-a3411cfe398a",
       "endDate": 1641601089568,
-      "startDate": 1641601089525,
       "sessionId": "b2ff55e1-c57e-4fc0-a003-54418278fa92",
-      "userId": "test-bac9ca22-8c8f-45a4-92a2-a3411cfe398a",
-      "ampSessionId": 1641601089490,
-      "ampDeviceId": "8520fd54-ab35-4a4c-9454-45e17605914e",
-      "statsFormat": "chrome_standard"
+      "startDate": 1641601089525,
+      "statsFormat": "chrome_standard",
+      "userId": "test-bac9ca22-8c8f-45a4-92a2-a3411cfe398a"
     },
     "features": {
-      "dominantSpeakerChanges": 1,
-      "faceLandmarksTimestamps": [],
-      "speakerTime": 3017,
-      "sentiment": {
-        "angry": 0,
-        "disgusted": 0,
-        "fearful": 0,
-        "happy": 0,
-        "neutral": 0,
-        "sad": 0,
-        "surprised": 0
-      },
-      "browserInfo": {
-        "majorVersion": "96",
-        "name": "Chrome",
-        "nameOs": "Chrome/OS X 10.15.7 64-bit",
-        "nameVersion": "Chrome/96.0.4664.110",
-        "nameVersionOs": "Chrome/96.0.4664.110/OS X 10.15.7 64-bit",
-        "os": "OS X 10.15.7 64-bit",
-        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36",
-        "version": "96.0.4664.110"
-      },
-      "deploymentInfo": {
-        "crossRegion": 0,
-        "envType": "dev",
-        "environment": "lonely",
-        "region": "us-west-2",
-        "releaseNumber": "",
-        "shard": "hcv-lonely-drno",
-        "userRegion": ""
-      },
-      "e2epings": {
-        "as458df9": {
-          "remoteRegion": "us-west-1",
-          "rtt": 223
-        }
-      },
-      "metrics": {
-        "conferenceDurationMs": 0,
-        "statsRequestBytes": 69628,
-        "statsRequestCount": 6,
-        "otherRequestBytes": 18914,
-        "otherRequestCount": 104,
-        "sdpRequestBytes": 2104,
-        "sdpRequestCount": 22,
-        "dsRequestBytes": 506,
-        "dsRequestCount": 3,
-        "totalProcessedBytes": 91152,
-        "totalProcessedCount": 135,
-        "sentimentRequestBytes": 0,
-        "sentimentRequestCount": 0,
-        "sessionDurationMs": 23040,
-        "dumpFileSizeBytes": 52090
-      },
       "aggregates": {
         "PC_0": {
-          "pcSessionDurationMs": 21036,
+          "connectionFailed": false,
           "dtlsErrors": 0,
           "dtlsFailure": 0,
-          "connectionFailed": false,
           "iceReconnects": 0,
+          "inboundVideoExperience": {
+            "lowerBoundAggregates": {
+              "meanFrameHeight": 720,
+              "meanFramesPerSecond": 30
+            },
+            "upperBoundAggregates": {
+              "meanFrameHeight": 720,
+              "meanFramesPerSecond": 30
+            }
+          },
           "isP2P": true,
           "lastIceDisconnect": 0,
           "lastIceFailure": 0,
-          "usesRelay": false,
+          "pcSessionDurationMs": 21036,
           "trackAggregates": {
-            "totalSentPacketsLost": 0,
-            "totalPacketsSent": 3947,
+            "receivedPacketsLostPct": 0,
             "sentPacketsLostPct": 0,
-            "totalReceivedPacketsLost": 0,
             "totalPacketsReceived": 4008,
-            "receivedPacketsLostPct": 0
+            "totalPacketsSent": 3947,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
           },
           "tracks": {
             "receiverTracks": [
@@ -132,34 +87,34 @@
           "transportAggregates": {
             "meanRtt": 0
           },
-          "inboundVideoExperience": {
-            "upperBoundAggregates": {
-              "meanFrameHeight": 720,
-              "meanFramesPerSecond": 30
-            },
-            "lowerBoundAggregates": {
-              "meanFrameHeight": 720,
-              "meanFramesPerSecond": 30
-            }
-          }
+          "usesRelay": false
         },
         "PC_1": {
-          "pcSessionDurationMs": 21254,
           "connectionFailed": false,
-          "iceReconnects": 0,
           "dtlsErrors": 0,
           "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "inboundVideoExperience": {
+            "lowerBoundAggregates": {
+              "meanFrameHeight": 720,
+              "meanFramesPerSecond": 27
+            },
+            "upperBoundAggregates": {
+              "meanFrameHeight": 720,
+              "meanFramesPerSecond": 27
+            }
+          },
           "isP2P": false,
           "lastIceDisconnect": 0,
           "lastIceFailure": 0,
-          "usesRelay": false,
+          "pcSessionDurationMs": 21254,
           "trackAggregates": {
-            "totalSentPacketsLost": 0,
-            "totalPacketsSent": 83,
+            "receivedPacketsLostPct": 0,
             "sentPacketsLostPct": 0,
-            "totalReceivedPacketsLost": 0,
             "totalPacketsReceived": 51,
-            "receivedPacketsLostPct": 0
+            "totalPacketsSent": 83,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
           },
           "tracks": {
             "receiverTracks": [
@@ -224,18 +179,63 @@
           "transportAggregates": {
             "meanRtt": 40.33
           },
-          "inboundVideoExperience": {
-            "upperBoundAggregates": {
-              "meanFrameHeight": 720,
-              "meanFramesPerSecond": 27
-            },
-            "lowerBoundAggregates": {
-              "meanFrameHeight": 720,
-              "meanFramesPerSecond": 27
-            }
-          }
+          "usesRelay": false
         }
-      } 
+      },
+      "browserInfo": {
+        "majorVersion": "96",
+        "name": "Chrome",
+        "nameOs": "Chrome/OS X 10.15.7 64-bit",
+        "nameVersion": "Chrome/96.0.4664.110",
+        "nameVersionOs": "Chrome/96.0.4664.110/OS X 10.15.7 64-bit",
+        "os": "OS X 10.15.7 64-bit",
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36",
+        "version": "96.0.4664.110"
+      },
+      "deploymentInfo": {
+        "crossRegion": 0,
+        "envType": "dev",
+        "environment": "lonely",
+        "region": "us-west-2",
+        "releaseNumber": "",
+        "shard": "hcv-lonely-drno",
+        "userRegion": ""
+      },
+      "dominantSpeakerChanges": 1,
+      "e2epings": {
+        "as458df9": {
+          "remoteRegion": "us-west-1",
+          "rtt": 223
+        }
+      },
+      "faceLandmarksTimestamps": [],
+      "metrics": {
+        "conferenceDurationMs": 0,
+        "dsRequestBytes": 506,
+        "dsRequestCount": 3,
+        "dumpFileSizeBytes": 52090,
+        "otherRequestBytes": 18914,
+        "otherRequestCount": 104,
+        "sdpRequestBytes": 2104,
+        "sdpRequestCount": 22,
+        "sentimentRequestBytes": 0,
+        "sentimentRequestCount": 0,
+        "sessionDurationMs": 23040,
+        "statsRequestBytes": 69628,
+        "statsRequestCount": 6,
+        "totalProcessedBytes": 91152,
+        "totalProcessedCount": 135
+      },
+      "sentiment": {
+        "angry": 0,
+        "disgusted": 0,
+        "fearful": 0,
+        "happy": 0,
+        "neutral": 0,
+        "sad": 0,
+        "surprised": 0
+      },
+      "speakerTime": 3017
     }
   }
 ]

--- a/src/test/jest/results/firefox-standard-stats-sfu-result.json
+++ b/src/test/jest/results/firefox-standard-stats-sfu-result.json
@@ -1,68 +1,29 @@
 [
   {
     "dumpInfo": {
+      "ampDeviceId": "60cba6ea-790a-4ec3-bf1c-b0d4f486c739",
+      "ampSessionId": 1641600699795,
       "app": "Integration Test",
       "clientId": "9195e361-2a5b-4749-923d-7f4d5d111c36",
       "conferenceUrl": "192.168.1.1/conf-9195e361-2a5b-4749-923d-7f4d5d111c36",
       "dumpPath": "/Users/nohlmeier/src/rtcstats-server/temp/9195e361-2a5b-4749-923d-7f4d5d111c36",
       "endDate": 1641600699878,
-      "startDate": 1641600699825,
       "sessionId": "d4fe59fa-d0ca-4984-9e8d-0ac8fd6780ed",
-      "userId": "test-9195e361-2a5b-4749-923d-7f4d5d111c36",
-      "ampSessionId": 1641600699795,
-      "ampDeviceId": "60cba6ea-790a-4ec3-bf1c-b0d4f486c739",
-      "statsFormat": "firefox"
+      "startDate": 1641600699825,
+      "statsFormat": "firefox",
+      "userId": "test-9195e361-2a5b-4749-923d-7f4d5d111c36"
     },
     "features": {
-      "dominantSpeakerChanges": 0,
-      "faceLandmarksTimestamps": [],
-      "speakerTime": 0,
-      "sentiment": {
-        "angry": 0,
-        "disgusted": 0,
-        "fearful": 0,
-        "happy": 0,
-        "neutral": 0,
-        "sad": 0,
-        "surprised": 0
-      },
-      "deploymentInfo": {
-        "crossRegion": 0,
-        "envType": "dev",
-        "environment": "lonely",
-        "region": "eu-west-1",
-        "releaseNumber": "",
-        "shard": "hcv-lonely-andreig2",
-        "userRegion": ""
-      },
-      "metrics": {
-        "conferenceDurationMs": 0,
-        "dsRequestBytes": 0,
-        "dsRequestCount": 0,
-        "dumpFileSizeBytes": 352003,
-        "otherRequestBytes": 12572,
-        "otherRequestCount": 55,
-        "sdpRequestBytes": 185530,
-        "sdpRequestCount": 12,
-        "sentimentRequestBytes": 0,
-        "sentimentRequestCount": 0,
-        "sessionDurationMs": 161480,
-        "statsRequestBytes": 496382,
-        "statsRequestCount": 79,
-        "totalProcessedBytes": 694484,
-        "totalProcessedCount": 146
-      },
       "aggregates": {
         "PC_0": {
-          "pcSessionDurationMs": 155540,
           "connectionFailed": false,
-          "iceReconnects": 0,
           "dtlsErrors": 0,
           "dtlsFailure": 0,
+          "iceReconnects": 0,
           "isP2P": false,
           "lastIceDisconnect": 0,
           "lastIceFailure": 0,
-          "usesRelay": false,
+          "pcSessionDurationMs": 155540,
           "trackAggregates": {
             "receivedPacketsLostPct": 0.01,
             "sentPacketsLostPct": 0,
@@ -187,9 +148,48 @@
           },
           "transportAggregates": {
             "meanRtt": 0.05
-          }
+          },
+          "usesRelay": false
         }
-      } 
+      },
+      "deploymentInfo": {
+        "crossRegion": 0,
+        "envType": "dev",
+        "environment": "lonely",
+        "region": "eu-west-1",
+        "releaseNumber": "",
+        "shard": "hcv-lonely-andreig2",
+        "userRegion": ""
+      },
+      "dominantSpeakerChanges": 0,
+      "faceLandmarksTimestamps": [],
+      "metrics": {
+        "conferenceDurationMs": 0,
+        "dsRequestBytes": 0,
+        "dsRequestCount": 0,
+        "dumpFileSizeBytes": 352003,
+        "otherRequestBytes": 12572,
+        "otherRequestCount": 55,
+        "sdpRequestBytes": 185530,
+        "sdpRequestCount": 12,
+        "sentimentRequestBytes": 0,
+        "sentimentRequestCount": 0,
+        "sessionDurationMs": 161480,
+        "statsRequestBytes": 496382,
+        "statsRequestCount": 79,
+        "totalProcessedBytes": 694484,
+        "totalProcessedCount": 146
+      },
+      "sentiment": {
+        "angry": 0,
+        "disgusted": 0,
+        "fearful": 0,
+        "happy": 0,
+        "neutral": 0,
+        "sad": 0,
+        "surprised": 0
+      },
+      "speakerTime": 0
     }
   }
 ]

--- a/src/test/jest/results/firefox97-standard-stats-sfu-result.json
+++ b/src/test/jest/results/firefox97-standard-stats-sfu-result.json
@@ -1,85 +1,36 @@
 [
   {
     "dumpInfo": {
+      "ampDeviceId": "d5f91167-4d2e-445b-a48d-492edcd3b3b9",
+      "ampSessionId": 1641864713012,
       "app": "Integration Test",
       "clientId": "9eb2f1a0-af02-443f-b97c-e415ecc857e7",
       "conferenceUrl": "192.168.1.1/conf-9eb2f1a0-af02-443f-b97c-e415ecc857e7",
       "dumpPath": "/Users/nohlmeier/src/rtcstats-server/temp/9eb2f1a0-af02-443f-b97c-e415ecc857e7",
       "endDate": 1641864713064,
-      "startDate": 1641864713041,
       "sessionId": "1e501074-10e3-48ec-99bd-9c402d53513c",
-      "userId": "test-9eb2f1a0-af02-443f-b97c-e415ecc857e7",
-      "ampSessionId": 1641864713012,
-      "ampDeviceId": "d5f91167-4d2e-445b-a48d-492edcd3b3b9",
-      "statsFormat": "firefox"
+      "startDate": 1641864713041,
+      "statsFormat": "firefox",
+      "userId": "test-9eb2f1a0-af02-443f-b97c-e415ecc857e7"
     },
     "features": {
-      "dominantSpeakerChanges": 2,
-      "faceLandmarksTimestamps": [],
-      "speakerTime": 19149,
-      "sentiment": {
-        "angry": 0,
-        "disgusted": 0,
-        "fearful": 0,
-        "happy": 0,
-        "neutral": 0,
-        "sad": 0,
-        "surprised": 0
-      },
-      "browserInfo": {
-        "majorVersion": "100",
-        "name": "Firefox",
-        "nameOs": "Firefox/OS X 10.15",
-        "nameVersion": "Firefox/100.0",
-        "nameVersionOs": "Firefox/100.0/OS X 10.15",
-        "os": "OS X 10.15",
-        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:100.0) Gecko/20100101 Firefox/100.0",
-        "version": "100.0"
-      },
-      "deploymentInfo": {
-        "crossRegion": 0,
-        "envType": "dev",
-        "environment": "lonely",
-        "region": "us-west-2",
-        "releaseNumber": "",
-        "shard": "hcv-lonely-drno",
-        "userRegion": ""
-      },
-      "metrics": {
-        "conferenceDurationMs": 0,
-        "statsRequestBytes": 36596,
-        "statsRequestCount": 8,
-        "otherRequestBytes": 7806,
-        "otherRequestCount": 37,
-        "sdpRequestBytes": 864,
-        "sdpRequestCount": 9,
-        "dsRequestBytes": 614,
-        "dsRequestCount": 3,
-        "totalProcessedBytes": 45880,
-        "totalProcessedCount": 57,
-        "sentimentRequestBytes": 0,
-        "sentimentRequestCount": 0,
-        "sessionDurationMs": 90460,
-        "dumpFileSizeBytes": 28534
-      },
       "aggregates": {
         "PC_0": {
-          "pcSessionDurationMs": 70587,
           "connectionFailed": false,
-          "iceReconnects": 0,
           "dtlsErrors": 0,
           "dtlsFailure": 0,
+          "iceReconnects": 0,
           "isP2P": false,
           "lastIceDisconnect": 0,
           "lastIceFailure": 0,
-          "usesRelay": false,
+          "pcSessionDurationMs": 70587,
           "trackAggregates": {
-            "totalSentPacketsLost": 0,
-            "totalPacketsSent": 0,
+            "receivedPacketsLostPct": 0,
             "sentPacketsLostPct": 0,
-            "totalReceivedPacketsLost": 28,
             "totalPacketsReceived": 4294935897,
-            "receivedPacketsLostPct": 0
+            "totalPacketsSent": 0,
+            "totalReceivedPacketsLost": 28,
+            "totalSentPacketsLost": 0
           },
           "tracks": {
             "receiverTracks": [
@@ -161,9 +112,58 @@
           },
           "transportAggregates": {
             "meanRtt": 0.04
-          }
+          },
+          "usesRelay": false
         }
-      }
+      },
+      "browserInfo": {
+        "majorVersion": "100",
+        "name": "Firefox",
+        "nameOs": "Firefox/OS X 10.15",
+        "nameVersion": "Firefox/100.0",
+        "nameVersionOs": "Firefox/100.0/OS X 10.15",
+        "os": "OS X 10.15",
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:100.0) Gecko/20100101 Firefox/100.0",
+        "version": "100.0"
+      },
+      "deploymentInfo": {
+        "crossRegion": 0,
+        "envType": "dev",
+        "environment": "lonely",
+        "region": "us-west-2",
+        "releaseNumber": "",
+        "shard": "hcv-lonely-drno",
+        "userRegion": ""
+      },
+      "dominantSpeakerChanges": 2,
+      "faceLandmarksTimestamps": [],
+      "metrics": {
+        "conferenceDurationMs": 0,
+        "dsRequestBytes": 614,
+        "dsRequestCount": 3,
+        "dumpFileSizeBytes": 28534,
+        "otherRequestBytes": 7806,
+        "otherRequestCount": 37,
+        "sdpRequestBytes": 864,
+        "sdpRequestCount": 9,
+        "sentimentRequestBytes": 0,
+        "sentimentRequestCount": 0,
+        "sessionDurationMs": 90460,
+        "statsRequestBytes": 36596,
+        "statsRequestCount": 8,
+        "totalProcessedBytes": 45880,
+        "totalProcessedCount": 57
+      },
+      "sentiment": {
+        "angry": 0,
+        "disgusted": 0,
+        "fearful": 0,
+        "happy": 0,
+        "neutral": 0,
+        "sad": 0,
+        "surprised": 0
+      },
+      "speakerTime": 19149
     }
   }
 ]

--- a/src/test/jest/results/google-standard-stats-p2p-result.json
+++ b/src/test/jest/results/google-standard-stats-p2p-result.json
@@ -1,68 +1,39 @@
 [
   {
     "dumpInfo": {
+      "ampDeviceId": "38e672be-5e96-4d19-905e-1692a81eb09c",
+      "ampSessionId": 1641600326907,
       "app": "Integration Test",
       "clientId": "83072254-e24b-4f8d-8162-23e94958ccb3",
       "conferenceUrl": "192.168.1.1/conf-83072254-e24b-4f8d-8162-23e94958ccb3",
       "dumpPath": "/Users/nohlmeier/src/rtcstats-server/temp/83072254-e24b-4f8d-8162-23e94958ccb3",
       "endDate": 1641600327015,
-      "startDate": 1641600326943,
       "sessionId": "bd918844-47a7-4985-a01d-22042108742a",
-      "userId": "test-83072254-e24b-4f8d-8162-23e94958ccb3",
-      "ampSessionId": 1641600326907,
-      "ampDeviceId": "38e672be-5e96-4d19-905e-1692a81eb09c",
-      "statsFormat": "chrome_standard"
+      "startDate": 1641600326943,
+      "statsFormat": "chrome_standard",
+      "userId": "test-83072254-e24b-4f8d-8162-23e94958ccb3"
     },
     "features": {
-      "dominantSpeakerChanges": 0,
-      "faceLandmarksTimestamps": [],
-      "speakerTime": 0,
-      "sentiment": {
-        "angry": 0,
-        "disgusted": 0,
-        "fearful": 0,
-        "happy": 0,
-        "neutral": 0,
-        "sad": 0,
-        "surprised": 0
-      },
-      "deploymentInfo": {
-        "crossRegion": 0,
-        "envType": "dev",
-        "environment": "lonely",
-        "region": "eu-west-1",
-        "releaseNumber": "",
-        "shard": "hcv-lonely-andreig2",
-        "userRegion": ""
-      },
-      "metrics": {
-        "conferenceDurationMs": 0,
-        "dsRequestBytes": 0,
-        "dsRequestCount": 0,
-        "dumpFileSizeBytes": 621030,
-        "otherRequestBytes": 48746,
-        "otherRequestCount": 108,
-        "sdpRequestBytes": 209774,
-        "sdpRequestCount": 24,
-        "sentimentRequestBytes": 0,
-        "sentimentRequestCount": 0,
-        "sessionDurationMs": 137304,
-        "statsRequestBytes": 971272,
-        "statsRequestCount": 81,
-        "totalProcessedBytes": 1229792,
-        "totalProcessedCount": 213
-      },
       "aggregates": {
         "PC_0": {
-          "pcSessionDurationMs": 54513,
           "connectionFailed": false,
-          "iceReconnects": 0,
           "dtlsErrors": 0,
           "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "inboundVideoExperience": {
+            "lowerBoundAggregates": {
+              "meanFrameHeight": 720,
+              "meanFramesPerSecond": 23.36
+            },
+            "upperBoundAggregates": {
+              "meanFrameHeight": 720,
+              "meanFramesPerSecond": 23.36
+            }
+          },
           "isP2P": true,
           "lastIceDisconnect": 0,
           "lastIceFailure": 0,
-          "usesRelay": false,
+          "pcSessionDurationMs": 54513,
           "trackAggregates": {
             "receivedPacketsLostPct": 0,
             "sentPacketsLostPct": 0,
@@ -116,27 +87,27 @@
           "transportAggregates": {
             "meanRtt": 0
           },
-          "inboundVideoExperience": {
-            "upperBoundAggregates": {
-              "meanFrameHeight": 720,
-              "meanFramesPerSecond": 23.36
-            },
-            "lowerBoundAggregates": {
-              "meanFrameHeight": 720,
-              "meanFramesPerSecond": 23.36
-            }
-          }
+          "usesRelay": false
         },
         "PC_1": {
-          "pcSessionDurationMs": 101282,
+          "connectionFailed": false,
           "dtlsErrors": 0,
           "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "inboundVideoExperience": {
+            "lowerBoundAggregates": {
+              "meanFrameHeight": 469.41,
+              "meanFramesPerSecond": 19.1
+            },
+            "upperBoundAggregates": {
+              "meanFrameHeight": 504.71,
+              "meanFramesPerSecond": 19.71
+            }
+          },
           "isP2P": false,
           "lastIceDisconnect": 0,
           "lastIceFailure": 0,
-          "usesRelay": false,
-          "connectionFailed": false,
-          "iceReconnects": 0,
+          "pcSessionDurationMs": 101282,
           "trackAggregates": {
             "receivedPacketsLostPct": 0.72,
             "sentPacketsLostPct": 0.17,
@@ -262,18 +233,47 @@
           "transportAggregates": {
             "meanRtt": 0.05
           },
-          "inboundVideoExperience": {
-            "upperBoundAggregates": {
-              "meanFrameHeight": 504.71,
-              "meanFramesPerSecond": 19.71
-            },
-            "lowerBoundAggregates": {
-              "meanFrameHeight": 469.41,
-              "meanFramesPerSecond": 19.1
-            }
-          }
+          "usesRelay": false
         }
-      }
+      },
+      "deploymentInfo": {
+        "crossRegion": 0,
+        "envType": "dev",
+        "environment": "lonely",
+        "region": "eu-west-1",
+        "releaseNumber": "",
+        "shard": "hcv-lonely-andreig2",
+        "userRegion": ""
+      },
+      "dominantSpeakerChanges": 0,
+      "faceLandmarksTimestamps": [],
+      "metrics": {
+        "conferenceDurationMs": 0,
+        "dsRequestBytes": 0,
+        "dsRequestCount": 0,
+        "dumpFileSizeBytes": 621030,
+        "otherRequestBytes": 48746,
+        "otherRequestCount": 108,
+        "sdpRequestBytes": 209774,
+        "sdpRequestCount": 24,
+        "sentimentRequestBytes": 0,
+        "sentimentRequestCount": 0,
+        "sessionDurationMs": 137304,
+        "statsRequestBytes": 971272,
+        "statsRequestCount": 81,
+        "totalProcessedBytes": 1229792,
+        "totalProcessedCount": 213
+      },
+      "sentiment": {
+        "angry": 0,
+        "disgusted": 0,
+        "fearful": 0,
+        "happy": 0,
+        "neutral": 0,
+        "sad": 0,
+        "surprised": 0
+      },
+      "speakerTime": 0
     }
   }
 ]

--- a/src/test/jest/results/google-standard-stats-sfu-result.json
+++ b/src/test/jest/results/google-standard-stats-sfu-result.json
@@ -1,68 +1,39 @@
 [
   {
     "dumpInfo": {
+      "ampDeviceId": "4982d7c4-01ae-4570-8599-09283b42766a",
+      "ampSessionId": 1641600611831,
       "app": "Integration Test",
       "clientId": "d0667072-0689-43bd-b34a-89e147cbf9ce",
       "conferenceUrl": "192.168.1.1/conf-d0667072-0689-43bd-b34a-89e147cbf9ce",
       "dumpPath": "/Users/nohlmeier/src/rtcstats-server/temp/d0667072-0689-43bd-b34a-89e147cbf9ce",
       "endDate": 1641600611905,
-      "startDate": 1641600611868,
       "sessionId": "4755c766-a069-4316-b1f1-54829dbc7a69",
-      "userId": "test-d0667072-0689-43bd-b34a-89e147cbf9ce",
-      "ampSessionId": 1641600611831,
-      "ampDeviceId": "4982d7c4-01ae-4570-8599-09283b42766a",
-      "statsFormat": "chrome_standard"
+      "startDate": 1641600611868,
+      "statsFormat": "chrome_standard",
+      "userId": "test-d0667072-0689-43bd-b34a-89e147cbf9ce"
     },
     "features": {
-      "dominantSpeakerChanges": 0,
-      "faceLandmarksTimestamps": [],
-      "speakerTime": 0,
-      "sentiment": {
-        "angry": 0,
-        "disgusted": 0,
-        "fearful": 0,
-        "happy": 0,
-        "neutral": 0,
-        "sad": 0,
-        "surprised": 0
-      },
-      "deploymentInfo": {
-        "crossRegion": 0,
-        "envType": "dev",
-        "environment": "lonely",
-        "region": "eu-west-1",
-        "releaseNumber": "",
-        "shard": "hcv-lonely-andreig2",
-        "userRegion": ""
-      },
-      "metrics": {
-        "conferenceDurationMs": 20286304,
-        "dsRequestBytes": 0,
-        "dsRequestCount": 0,
-        "dumpFileSizeBytes": 286674,
-        "otherRequestBytes": 11118,
-        "otherRequestCount": 38,
-        "sdpRequestBytes": 19664,
-        "sdpRequestCount": 3,
-        "sentimentRequestBytes": 0,
-        "sentimentRequestCount": 0,
-        "sessionDurationMs": 77001,
-        "statsRequestBytes": 532462,
-        "statsRequestCount": 34,
-        "totalProcessedBytes": 563244,
-        "totalProcessedCount": 75
-      },
       "aggregates": {
         "PC_0": {
-          "pcSessionDurationMs": 65094,
+          "connectionFailed": false,
           "dtlsErrors": 0,
           "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "inboundVideoExperience": {
+            "lowerBoundAggregates": {
+              "meanFrameHeight": 180,
+              "meanFramesPerSecond": 28.85
+            },
+            "upperBoundAggregates": {
+              "meanFrameHeight": 720,
+              "meanFramesPerSecond": 27.82
+            }
+          },
           "isP2P": false,
           "lastIceDisconnect": 0,
           "lastIceFailure": 0,
-          "usesRelay": false,
-          "connectionFailed": false,
-          "iceReconnects": 0,
+          "pcSessionDurationMs": 65094,
           "trackAggregates": {
             "receivedPacketsLostPct": 0.05,
             "sentPacketsLostPct": 0,
@@ -152,18 +123,47 @@
           "transportAggregates": {
             "meanRtt": 0.05
           },
-          "inboundVideoExperience": {
-            "upperBoundAggregates": {
-              "meanFrameHeight": 720,
-              "meanFramesPerSecond": 27.82
-            },
-            "lowerBoundAggregates": {
-              "meanFrameHeight": 180,
-              "meanFramesPerSecond": 28.85
-            }
-          }
+          "usesRelay": false
         }
-      }
+      },
+      "deploymentInfo": {
+        "crossRegion": 0,
+        "envType": "dev",
+        "environment": "lonely",
+        "region": "eu-west-1",
+        "releaseNumber": "",
+        "shard": "hcv-lonely-andreig2",
+        "userRegion": ""
+      },
+      "dominantSpeakerChanges": 0,
+      "faceLandmarksTimestamps": [],
+      "metrics": {
+        "conferenceDurationMs": 20286304,
+        "dsRequestBytes": 0,
+        "dsRequestCount": 0,
+        "dumpFileSizeBytes": 286674,
+        "otherRequestBytes": 11118,
+        "otherRequestCount": 38,
+        "sdpRequestBytes": 19664,
+        "sdpRequestCount": 3,
+        "sentimentRequestBytes": 0,
+        "sentimentRequestCount": 0,
+        "sessionDurationMs": 77001,
+        "statsRequestBytes": 532462,
+        "statsRequestCount": 34,
+        "totalProcessedBytes": 563244,
+        "totalProcessedCount": 75
+      },
+      "sentiment": {
+        "angry": 0,
+        "disgusted": 0,
+        "fearful": 0,
+        "happy": 0,
+        "neutral": 0,
+        "sad": 0,
+        "surprised": 0
+      },
+      "speakerTime": 0
     }
   }
 ]

--- a/src/test/jest/results/safari-standard-stats-result.json
+++ b/src/test/jest/results/safari-standard-stats-result.json
@@ -1,68 +1,29 @@
 [
   {
     "dumpInfo": {
+      "ampDeviceId": "f0892dc7-0f9c-4e39-9e9b-0924ec51fa27",
+      "ampSessionId": 1641941576018,
       "app": "Integration Test",
       "clientId": "9f2af46d-0dc9-4040-b1fa-f4bb55f8ab19",
       "conferenceUrl": "192.168.1.1/conf-9f2af46d-0dc9-4040-b1fa-f4bb55f8ab19",
       "dumpPath": "/Users/nohlmeier/src/rtcstats-server/temp/9f2af46d-0dc9-4040-b1fa-f4bb55f8ab19",
       "endDate": 1641941576116,
-      "startDate": 1641941576052,
       "sessionId": "4567a1ea-9b53-4249-812b-e9986eb12423",
-      "userId": "test-9f2af46d-0dc9-4040-b1fa-f4bb55f8ab19",
-      "ampSessionId": 1641941576018,
-      "ampDeviceId": "f0892dc7-0f9c-4e39-9e9b-0924ec51fa27",
-      "statsFormat": "safari"
+      "startDate": 1641941576052,
+      "statsFormat": "safari",
+      "userId": "test-9f2af46d-0dc9-4040-b1fa-f4bb55f8ab19"
     },
     "features": {
-      "dominantSpeakerChanges": 0,
-      "faceLandmarksTimestamps": [],
-      "speakerTime": 0,
-      "sentiment": {
-        "angry": 0,
-        "disgusted": 0,
-        "fearful": 0,
-        "happy": 0,
-        "neutral": 0,
-        "sad": 0,
-        "surprised": 0
-      },
-      "deploymentInfo": {
-        "crossRegion": 0,
-        "envType": "dev",
-        "environment": "lonely",
-        "region": "eu-west-1",
-        "releaseNumber": "",
-        "shard": "hcv-lonely-andreig2",
-        "userRegion": ""
-      },
-      "metrics": {
-        "conferenceDurationMs": 0,
-        "dsRequestBytes": 0,
-        "dsRequestCount": 0,
-        "dumpFileSizeBytes": 729058,
-        "otherRequestBytes": 14256,
-        "otherRequestCount": 69,
-        "sdpRequestBytes": 424746,
-        "sdpRequestCount": 21,
-        "sentimentRequestBytes": 0,
-        "sentimentRequestCount": 0,
-        "sessionDurationMs": 233769,
-        "statsRequestBytes": 1009542,
-        "statsRequestCount": 82,
-        "totalProcessedBytes": 1448544,
-        "totalProcessedCount": 172
-      },
       "aggregates": {
         "PC_0": {
-          "pcSessionDurationMs": 227263,
+          "connectionFailed": false,
           "dtlsErrors": 0,
           "dtlsFailure": 0,
+          "iceReconnects": 0,
           "isP2P": false,
           "lastIceDisconnect": 0,
           "lastIceFailure": 0,
-          "usesRelay": false,
-          "connectionFailed": false,
-          "iceReconnects": 0,
+          "pcSessionDurationMs": 227263,
           "trackAggregates": {
             "receivedPacketsLostPct": 0,
             "sentPacketsLostPct": 0,
@@ -187,9 +148,48 @@
           },
           "transportAggregates": {
             "meanRtt": 0.05
-          }
+          },
+          "usesRelay": false
         }
-      }   
+      },
+      "deploymentInfo": {
+        "crossRegion": 0,
+        "envType": "dev",
+        "environment": "lonely",
+        "region": "eu-west-1",
+        "releaseNumber": "",
+        "shard": "hcv-lonely-andreig2",
+        "userRegion": ""
+      },
+      "dominantSpeakerChanges": 0,
+      "faceLandmarksTimestamps": [],
+      "metrics": {
+        "conferenceDurationMs": 0,
+        "dsRequestBytes": 0,
+        "dsRequestCount": 0,
+        "dumpFileSizeBytes": 729058,
+        "otherRequestBytes": 14256,
+        "otherRequestCount": 69,
+        "sdpRequestBytes": 424746,
+        "sdpRequestCount": 21,
+        "sentimentRequestBytes": 0,
+        "sentimentRequestCount": 0,
+        "sessionDurationMs": 233769,
+        "statsRequestBytes": 1009542,
+        "statsRequestCount": 82,
+        "totalProcessedBytes": 1448544,
+        "totalProcessedCount": 172
+      },
+      "sentiment": {
+        "angry": 0,
+        "disgusted": 0,
+        "fearful": 0,
+        "happy": 0,
+        "neutral": 0,
+        "sad": 0,
+        "surprised": 0
+      },
+      "speakerTime": 0
     }
   }
 ]

--- a/src/test/jest/results/undefined-ice-candidate-result.json
+++ b/src/test/jest/results/undefined-ice-candidate-result.json
@@ -1,6 +1,9 @@
 [
   {
     "dumpInfo": {
+      "ampDeviceId": "7b84dd7e-7c68-4e52-8e69-b0d2833ebdaaR",
+      "ampSessionId": 1646895708035,
+      "ampUserId": null,
       "app": "Jitsi Meet",
       "clientId": "050bf1c4-8d52-43dd-ba94-8b58089f0020",
       "conferenceId": "xxxxxxxxxxzu2pFGyp7mBrP7RdvzNcsEPXj7pmGDcNGw",
@@ -8,43 +11,39 @@
       "dumpPath": "/rtcstats-server/temp/050bf1c4-8d52-43dd-ba94-8b58089f0020",
       "endDate": 1646901926175,
       "endpointId": "cced643e",
-      "startDate": 1646901906018,
       "sessionId": "41c8f2f2-eab3-49c7-b568-6d7d4e51fb81",
-      "userId": "Lyda-hGl",
-      "ampSessionId": 1646895708035,
-      "ampUserId": null,
-      "ampDeviceId": "7b84dd7e-7c68-4e52-8e69-b0d2833ebdaaR",
-      "statsFormat": "chrome_standard"
+      "startDate": 1646901906018,
+      "statsFormat": "chrome_standard",
+      "userId": "Lyda-hGl"
     },
     "features": {
-      "dominantSpeakerChanges": 0,
-      "faceLandmarksTimestamps": [],
-      "speakerTime": 0,
-      "sentiment": {
-        "angry": 0,
-        "disgusted": 0,
-        "fearful": 0,
-        "happy": 0,
-        "neutral": 0,
-        "sad": 0,
-        "surprised": 0
-      },
-      "metrics": {
-        "conferenceDurationMs": 0,
-        "statsRequestBytes": 217880,
-        "statsRequestCount": 3,
-        "otherRequestBytes": 15674,
-        "otherRequestCount": 74,
-        "sdpRequestBytes": 576,
-        "sdpRequestCount": 6,
-        "dsRequestBytes": 218,
-        "dsRequestCount": 1,
-        "totalProcessedBytes": 234348,
-        "totalProcessedCount": 84,
-        "sentimentRequestBytes": 0,
-        "sentimentRequestCount": 0,
-        "sessionDurationMs": 32571,
-        "dumpFileSizeBytes": 123929
+      "aggregates": {
+        "PC_0": {
+          "connectionFailed": true,
+          "dtlsErrors": 0,
+          "dtlsFailure": 0,
+          "iceReconnects": 0,
+          "isP2P": false,
+          "lastIceDisconnect": 1646901911025,
+          "lastIceFailure": 0,
+          "pcSessionDurationMs": 0,
+          "trackAggregates": {
+            "receivedPacketsLostPct": 0,
+            "sentPacketsLostPct": 0,
+            "totalPacketsReceived": 0,
+            "totalPacketsSent": 0,
+            "totalReceivedPacketsLost": 0,
+            "totalSentPacketsLost": 0
+          },
+          "tracks": {
+            "receiverTracks": [],
+            "senderTracks": []
+          },
+          "transportAggregates": {
+            "meanRtt": 0.08
+          },
+          "usesRelay": false
+        }
       },
       "browserInfo": {
         "majorVersion": "99",
@@ -65,34 +64,35 @@
         "shard": "meet-jit-si-eu-central-1a-s40",
         "userRegion": "eu-central-1"
       },
-      "aggregates": {
-        "PC_0": {
-          "pcSessionDurationMs": 0,
-          "connectionFailed": true,
-          "iceReconnects": 0,
-          "isP2P": false,
-          "lastIceDisconnect": 1646901911025,
-          "lastIceFailure": 0,
-          "usesRelay": false,
-          "dtlsErrors": 0,
-          "dtlsFailure": 0,
-          "tracks": {
-            "receiverTracks": [],
-            "senderTracks": []
-          },
-          "trackAggregates": {
-            "totalSentPacketsLost": 0,
-            "totalPacketsSent": 0,
-            "sentPacketsLostPct": 0,
-            "totalReceivedPacketsLost": 0,
-            "totalPacketsReceived": 0,
-            "receivedPacketsLostPct": 0
-          },
-          "transportAggregates": {
-            "meanRtt": 0.08
-          }
-        }
-      }
+      "dominantSpeakerChanges": 0,
+      "faceLandmarksTimestamps": [],
+      "metrics": {
+        "conferenceDurationMs": 0,
+        "dsRequestBytes": 218,
+        "dsRequestCount": 1,
+        "dumpFileSizeBytes": 123929,
+        "otherRequestBytes": 15674,
+        "otherRequestCount": 74,
+        "sdpRequestBytes": 576,
+        "sdpRequestCount": 6,
+        "sentimentRequestBytes": 0,
+        "sentimentRequestCount": 0,
+        "sessionDurationMs": 32571,
+        "statsRequestBytes": 217880,
+        "statsRequestCount": 3,
+        "totalProcessedBytes": 234348,
+        "totalProcessedCount": 84
+      },
+      "sentiment": {
+        "angry": 0,
+        "disgusted": 0,
+        "fearful": 0,
+        "happy": 0,
+        "neutral": 0,
+        "sad": 0,
+        "surprised": 0
+      },
+      "speakerTime": 0
     }
   }
 ]


### PR DESCRIPTION
This commit makes it possible to mass update the test results. The use-case is
the following:

Suppose, for example, that you have modified the feature extractor to add a
`startDate` field in the track features. When you run the tests they fail and
they present you with the diff. After you have reviewed the diff and you are
satisfied with the result you will need to update all the JSON results
accordingly so that the Jest tests actually pass. With this commit you can
simply run `npm run test:fix` to do that last part.

As a bonus point, this procedure will enforce uniform formatting rules for our
JSON result files. If you notice currently we have some with 2-space
indentation and others with 4-space indentation.

The way `npm run test:fix` is that it will generate a stringified JSON with a
special replacer that garantees that properties/fields of the stringified
object will be sorted so the stringified representation is truly stable.

Note that I have already run `npm run test:fix` which has re-formatted the JSON
result files but their contained hasn't changed.