### PR TITLE
feat: add endpoint config for S3 and DynamoDB

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -17,9 +17,11 @@ firehose:
 s3:
     region: RTCSTATS_S3_AWS_REGION
     bucket: RTCSTATS_S3_BUCKET
+    endpoint: RTCSTATS_S3_ENDPOINT
 
 dynamo:
     tableName: RTCSTATS_METADATA_TABLE
+    endpoint: RTCSTATS_DYNAMODB_ENDPOINT
 
 webhooks:
     apiEndpoint: RTCSTATS_WEBHOOK_ENDPOINT

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -27,6 +27,7 @@ s3:
     useIAMAuth:
     # Default value is 2 days
     signedLinkExpirationSec: 172800
+    endpoint:
 
 firehose:
     accessKeyId:

--- a/src/store/S3Manager.js
+++ b/src/store/S3Manager.js
@@ -16,7 +16,7 @@ class S3Manager {
      * @param {*} config - Configuration object that contains S3 settings such as region, bucket, etc.
      */
     constructor(config) {
-        const { region, useIAMAuth, bucket, signedLinkExpirationSec } = config;
+        const { region, useIAMAuth, bucket, signedLinkExpirationSec, endpoint } = config;
 
         assert(region);
         assert(bucket);
@@ -27,11 +27,9 @@ class S3Manager {
             AWS.config = config;
         }
 
-        this.s3bucket = new AWS.S3({
-            params: {
-                Bucket: bucket
-            }
-        });
+        // Use endpoint for local S3 (e.g., MinIO or LocalStack).
+        // Falls back to default AWS S3 if no endpoint is specified.
+        this.s3bucket = new AWS.S3(endpoint ? { endpoint } : {});
 
         this.bucket = bucket;
         this.signedLinkExpirationSec = signedLinkExpirationSec;
@@ -50,6 +48,7 @@ class S3Manager {
         const compressedStream = readStream.pipe(gzipStream);
 
         return this.s3bucket.upload({
+            Bucket: this.bucket,
             Key: key,
             Body: compressedStream
         }).promise();


### PR DESCRIPTION
This PR adds support for configuring custom S3 and DynamoDB endpoints via environment variables, to enable local development with tools like LocalStack.